### PR TITLE
Compute count and sum during aggregation of verification results

### DIFF
--- a/workflow/scripts/verif_aggregation.py
+++ b/workflow/scripts/verif_aggregation.py
@@ -68,15 +68,13 @@ def aggregate_results(df: pd.DataFrame) -> pd.DataFrame:
     # concatenate all versions
     df_extended = pd.concat(groupings, ignore_index=True)
 
-    # group and compute mean
-    mean_scores = (
-        df_extended
-        .groupby(["metric", "lead_time", "param", "hour", "season", "init_hour"], dropna=False)["value"]
-        .mean()
-        .reset_index()
-    )
-
-    return mean_scores
+    # aggregate
+    aggregated = df_extended.groupby(
+        ["metric", "lead_time", "param", "hour", "season", "init_hour"],
+        dropna=False  # optional, ensures NaN values are not dropped
+    ).agg(value_mean=("value", "mean"), value_count=("value", "count"), value_sum=("value","sum")).reset_index()
+    
+    return aggregated
 
 def main(args: Namespace) -> None:
     """Main function to verify results from KENDA-1 data."""

--- a/workflow/scripts/verif_plot_metrics.py
+++ b/workflow/scripts/verif_plot_metrics.py
@@ -103,7 +103,7 @@ def main(args: Namespace) -> None:
             # convert lead time to integer hours
             df["lead_time"] = df["lead_time"].dt.total_seconds() / 3600
             df.plot(
-                x="lead_time", y="value", kind="line",
+                x="lead_time", y="value_mean", kind="line",
                 title=title,
                 xlabel="Lead Time", ylabel=metric,
                 label=labels[i],


### PR DESCRIPTION
This PR extends the aggregation of the verification results by computing the counts and the total sum for any given group. This will allow more flexible combinations downstream. 