### PR TITLE
Specify dates as an explicit list

### DIFF
--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Dict, List
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl, RootModel
 
 
 class Dates(BaseModel):
@@ -20,6 +20,10 @@ class Dates(BaseModel):
         description="Time between initialisations. Must be a combination of a number and a time unit (h or d).",
         pattern=r"^\d+[hd]$",
     )
+
+
+class ExplicitDates(RootModel[List[str]]):
+    """Explicit list of initialisation dates as ISO-8601 formatted strings."""
 
 
 class RunConfig(BaseModel):
@@ -91,7 +95,7 @@ class ExperimentConfig(BaseModel):
         ...,
         description="Description of the experiment, e.g. 'Hindcast of the 2023 season.'",
     )
-    dates: Dates
+    dates: Dates | ExplicitDates
     lead_time: str = Field(
         ..., description="Forecast length, e.g. '120h'", pattern=r"^\d+[hmd]$"
     )

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -79,6 +79,14 @@
       "title": "Execution",
       "type": "object"
     },
+    "ExplicitDates": {
+      "description": "Explicit list of initialisation dates as ISO-8601 formatted strings.",
+      "items": {
+        "type": "string"
+      },
+      "title": "ExplicitDates",
+      "type": "array"
+    },
     "Locations": {
       "description": "Locations of data and services used in the workflow.",
       "properties": {
@@ -166,7 +174,15 @@
       "type": "string"
     },
     "dates": {
-      "$ref": "#/$defs/Dates"
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Dates"
+        },
+        {
+          "$ref": "#/$defs/ExplicitDates"
+        }
+      ],
+      "title": "Dates"
     },
     "lead_time": {
       "description": "Forecast length, e.g. '120h'",


### PR DESCRIPTION
Dates can be now specified in the config also as an explicit list.

With this change, both:

```yaml
dates:
  - 2020-01-01T12:00
  - 2020-04-03T18:00
```

or 

```yaml
dates:
  start: 2020-01-01T12:00
  end: 2020-01-10T00:00
  frequency: 54h
```

are valid configurations.