### PR TITLE
Fix issues with analysis-based evaluation of precipitation

### DIFF
--- a/workflow/scripts/verif_cosmoe_fct.py
+++ b/workflow/scripts/verif_cosmoe_fct.py
@@ -180,10 +180,10 @@ def main(args: ScriptConfig):
             coe.TOT_PREC.attrs["units"] = "m"
         ## disaggregate precipitation
         coe = coe.assign(
-            TOT_PREC = lambda x: (
+            TOT_PREC=lambda x: (
                 x.TOT_PREC.fillna(0)
                 .diff("lead_time")
-                .pad(lead_time = (1,0), constant_value = None)
+                .pad(lead_time=(1, 0), constant_value=None)
             )
         )
     coe = coe[args.params].sel(

--- a/workflow/scripts/verif_from_grib.py
+++ b/workflow/scripts/verif_from_grib.py
@@ -154,7 +154,7 @@ def load_fct_data_from_grib(
             TOT_PREC=lambda x: (
                 x.TOT_PREC.fillna(0)
                 .diff("lead_time")
-                .pad(lead_time = (1,0), constant_value = None)
+                .pad(lead_time=(1, 0), constant_value=None)
             )
         )
     return ds


### PR DESCRIPTION
This PR attempts at fixing two remaining issues with the evaluation of precipitation:

* COSMO-E precipitation is in `kg m-2` whereas precip in the analysis and ML forecasts is in `m`. To avoid making all parts of the evaluation pipeline units aware, a quick fix is introduced just for precipitation from COSMO-E.
* Forecast precipitation is aggregated (i.e. totals from start of integration), whereas the analysis is disaggregated (i.e. 6h totals). To allow for a meaningful comparison, forecast precipitation needs to be disaggregated.


### Changes Applied
* change units of COSMO-E precipitation to `m`

### Result
<img width="1000" height="600" alt="BIAS_TOT_PREC" src="https://github.com/user-attachments/assets/07059824-a4e4-4928-b1ca-f60a60cc8e71" />
<img width="1000" height="600" alt="RMSE_TOT_PREC" src="https://github.com/user-attachments/assets/4c772566-29f2-43c7-a9b5-feeadef2cd24" />

