### PR TITLE
Add setting for global resources

### DIFF
--- a/config/forecasters.yaml
+++ b/config/forecasters.yaml
@@ -37,9 +37,12 @@ locations:
 
 profile:
   executor: slurm
+  global_resources:
+    gpus: 15
   default_resources:
     slurm_partition: "postproc"
     cpus_per_task: 1
     mem_mb_per_cpu: 1800
     runtime: "1h"
-  jobs: 10
+    gpus: 0
+  jobs: 50

--- a/config/interpolators.yaml
+++ b/config/interpolators.yaml
@@ -29,6 +29,7 @@ runs:
         config: resources/inference/configs/forecaster_with_global.yaml
       extra_dependencies:
         - git+https://github.com/MeteoSwiss/anemoi-inference@fix/interp_files
+        #  - git+https://github.com/ecmwf/anemoi-inference@fix/interp_files
         - torch-geometric==2.6.1
         - anemoi-graphs==0.5.2
   - interpolator:
@@ -41,6 +42,7 @@ runs:
         config: resources/inference/configs/forecaster_with_global.yaml
       extra_dependencies:
         - git+https://github.com/MeteoSwiss/anemoi-inference@fix/interp_files
+        #  - git+https://github.com/ecmwf/anemoi-inference@fix/interp_files
         - torch-geometric==2.6.1
         - anemoi-graphs==0.5.2
 
@@ -64,9 +66,12 @@ locations:
 
 profile:
   executor: slurm
+  global_resources:
+    gpus: 15
   default_resources:
     slurm_partition: "postproc"
     cpus_per_task: 1
     mem_mb_per_cpu: 1800
     runtime: "1h"
-  jobs: 10
+    gpus: 0
+  jobs: 50

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -160,10 +160,34 @@ class DefaultResources(BaseModel):
         return [f"{key}={value}" for key, value in self.model_dump().items()]
 
 
+class GlobalResources(BaseModel):
+    """
+    Define resource limits that apply across all submissions.
+
+    This model is intended to specify global constraints, such as
+    the maximum number of GPUs that can be allocated in parallel,
+    regardless of individual job settings.
+    """
+
+    gpus: int = Field(
+        ...,
+        ge=1,
+        description=(
+            "Maximum number of GPUs that may be used concurrently "
+            "across all submissions."
+        ),
+    )
+
+    def parsable(self) -> str:
+        """Convert the global resources to a string of key=value pairs."""
+        return [f"{key}={value}" for key, value in self.model_dump().items()]
+
+
 class Profile(BaseModel):
     """Workflow execution profile."""
 
     executor: str = Field(..., description="Job executor, e.g. 'slurm'.")
+    global_resources: GlobalResources
     default_resources: DefaultResources
     jobs: int = Field(..., ge=1, description="Maximum number of parallel jobs.")
 
@@ -171,6 +195,7 @@ class Profile(BaseModel):
         """Convert the profile to a dictionary of command-line arguments."""
         out = []
         out += ["--executor", self.executor]
+        out += ["--resources"] + self.global_resources.parsable()
         out += ["--default-resources"] + self.default_resources.parsable()
         out += ["--jobs", str(self.jobs)]
         return out

--- a/workflow/rules/inference.smk
+++ b/workflow/rules/inference.smk
@@ -133,6 +133,7 @@ rule inference_forecaster:
         runtime="20m",
         gres="gpu:1",
         slurm_extra=lambda wc, input: f"--uenv={Path(input.image).resolve()}:/user-environment",
+        gpus=1,
     shell:
         """
         (
@@ -206,6 +207,7 @@ rule inference_interpolator:
         runtime="30m",
         gres="gpu:1",
         slurm_extra=lambda wc, input: f"--uenv={Path(input.image).resolve()}:/user-environment",
+        gpus=1,
     shell:
         """
         (

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -219,6 +219,22 @@
       "title": "ForecasterItem",
       "type": "object"
     },
+    "GlobalResources": {
+      "description": "Set global constraints across all submissions (e.g. number of API calls per second).",
+      "properties": {
+        "gpus": {
+          "description": "Maximum number of GPUs to be used in parallel.",
+          "minimum": 1,
+          "title": "Gpus",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "gpus"
+      ],
+      "title": "GlobalResources",
+      "type": "object"
+    },
     "InterpolatorConfig": {
       "description": "Single training run stored in MLflow.",
       "properties": {
@@ -343,6 +359,9 @@
           "title": "Executor",
           "type": "string"
         },
+        "global_resources": {
+          "$ref": "#/$defs/GlobalResources"
+        },
         "default_resources": {
           "$ref": "#/$defs/DefaultResources"
         },
@@ -355,6 +374,7 @@
       },
       "required": [
         "executor",
+        "global_resources",
         "default_resources",
         "jobs"
       ],


### PR DESCRIPTION
Currently, we can indicate the number of parallel SLURM jobs via the config file. However, in principle this number might change depending on the resource being used. For example, we should control the maxim number of GPUs used in parallel, as we have to follow internal guidelines. 

This PR introduces global resources that apply across all submissions. The relative snakemake documentation for this feature is available here https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#resources-and-remote-execution

>  resources may represent either a global constraint across all submissions (e.g. number of API calls per second), or a constraint local to each specific job sumbmission (e.g. the amount of memory available on a node). [...] By default, mem_mb, disk_mb, and threads are all considered "local" resources, meaning specific to individual submissions. [...] All other resources are considered "global", meaning they are tracked across all jobs across all submissions. For example, if api_calls was limited to 5 and each job scheduled used 1 api call, only 5 jobs would be scheduled at a time, even if more job submissions were available.

In our case, we define a new `gpus=15` (global) resource and set `gpus=1` for the inference rules, so that snakemake will schedule at max 15 concurrent jobs on gpu nodes.