### PR TITLE
Update configs

### DIFF
--- a/resources/inference/configs/forecaster.yaml
+++ b/resources/inference/configs/forecaster.yaml
@@ -4,7 +4,6 @@ input:
 
 allow_nans: true
 
-
 output:
   tee:
     outputs:

--- a/resources/inference/configs/interpolator.yaml
+++ b/resources/inference/configs/interpolator.yaml
@@ -56,7 +56,7 @@ output:
     templates:
       samples: _resources/templates_index_cosmo.yaml
 
-forcings:
+constant_forcings:
   test:
     use_original_paths: true
 

--- a/resources/inference/configs/interpolator_from_test_data.yaml
+++ b/resources/inference/configs/interpolator_from_test_data.yaml
@@ -17,10 +17,6 @@ output:
     templates:
       samples: _resources/templates_index_cosmo.yaml
 
-forcings:
-  test:
-    use_original_paths: true
-
 verbosity: 1
 allow_nans: true
 output_frequency: "1h"

--- a/resources/inference/configs/interpolator_from_test_data_stretched.yaml
+++ b/resources/inference/configs/interpolator_from_test_data_stretched.yaml
@@ -1,0 +1,24 @@
+runner: time_interpolator
+
+input:
+  test:
+    use_original_paths: true
+
+output:
+  tee:
+    outputs:
+      - extract_lam:
+          output:
+            assign_mask:
+              mask: "source0/trimedge_mask"
+              output:
+                grib:
+                  path: grib/{dateTime}_{step:03}.grib
+                  encoding:
+                    typeOfGeneratingProcess: 2
+                  templates:
+                    samples: _resources/templates_index_cosmo.yaml
+
+verbosity: 1
+allow_nans: true
+output_frequency: "1h"

--- a/resources/inference/configs/interpolator_stretched.yaml
+++ b/resources/inference/configs/interpolator_stretched.yaml
@@ -79,7 +79,7 @@ input:
             - - shortName: TOT_PREC
               - tp
 
-forcings:
+constant_forcings:
   test:
     use_original_paths: true
 


### PR DESCRIPTION
Changes during review of anemoi-inference PR involved to remove the key `forcings` from the config but replace it with `constant_forcings`, which was what was needed in our case but avoid unnecessary changes in anemoi.
Also added new config to run stretched interpolator from test data.