### PR TITLE
Distinguish between primary runs ('candidates') and secondary runs

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -54,7 +54,7 @@ rule sandbox_all:
     input:
         expand(
             rules.create_inference_sandbox.output.sandbox,
-            run_id=collect_all_runs(),
+            run_id=collect_all_candidates(),
         ),
 
 
@@ -64,7 +64,7 @@ rule run_inference_all:
         expand(
             OUT_ROOT / "data/runs/{run_id}/{init_time}/raw",
             init_time=[t.strftime("%Y%m%d%H%M") for t in REFTIMES],
-            run_id=collect_all_runs(),
+            run_id=collect_all_candidates(),
         ),
 
 
@@ -73,7 +73,7 @@ rule verif_metrics_all:
         expand(
             rules.verif_metrics.output,
             init_time=[t.strftime("%Y%m%d%H%M") for t in REFTIMES],
-            run_id=collect_all_runs(),
+            run_id=collect_all_candidates(),
         ),
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -93,7 +93,7 @@ def collect_all_runs():
 
 
 def collect_all_candidates():
-    """Collect primary runs only."""
+    """Collect participating runs ('candidates') only."""
     runs = collect_all_runs()
     candidates = {}
     for run_id, run_config in runs.items():


### PR DESCRIPTION
Currently results are produced for ALL runs specified in the evalml config, including forecasters that are there only to produce inputs for interpolators. Instead, only "primary" runs should be listed. I call now those "candidates".