### PR TITLE
Add make command to CLI

### DIFF
--- a/src/evalml/cli.py
+++ b/src/evalml/cli.py
@@ -128,9 +128,7 @@ def showcase(configfile, cores, verbose, dry_run, unlock, report, extra_smk_args
     )
 
 
-@cli.command(
-    help="Generate a sandbox for inference for the runs defined in the config YAML file."
-)
+@cli.command(help="Generate a sandbox for inference runs in the YAML config file.")
 @click.argument(
     "configfile", type=click.Path(exists=True, dir_okay=False, path_type=Path)
 )
@@ -139,6 +137,25 @@ def sandbox(configfile, cores, verbose, dry_run, unlock, report, extra_smk_args)
     execute_workflow(
         configfile,
         "sandbox_all",
+        cores,
+        verbose,
+        dry_run,
+        unlock,
+        report,
+        extra_smk_args,
+    )
+
+
+@cli.command(help="Make a specific file from a workflow defined in the YAML file.")
+@click.argument(
+    "configfile", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.argument("target", type=str)
+@workflow_options
+def make(configfile, target, cores, verbose, dry_run, unlock, report, extra_smk_args):
+    execute_workflow(
+        configfile,
+        target,
         cores,
         verbose,
         dry_run,


### PR DESCRIPTION
Sometimes we just want to create a single file, for example when debugging. This new command allows to specify that single file as a target, and only run the workflow to generate that file. 

For example:

```shell
evalml make config/interpolators.yaml output/data/runs/8d1e0410c-d0846032f/verif_aggregated.nc
```

Gotcha: the file must be one that would be generated by the provided config (e.g. I cannot make a file from an interpolator using the `forecasters.yaml` config). 