### PR TITLE
Override automatic cluster detection

### DIFF
--- a/workflow/rules/inference.smk
+++ b/workflow/rules/inference.smk
@@ -253,7 +253,7 @@ rule execute_inference:
 
         CMD_ARGS=()
 
-        # is GPU > 1, add runner=parallel to CMD_ARGS
+        # is GPU > 1, add parallel flag to CMD_ARGS and override automatic cluster detection
         if [ {resources.gpus} -gt 1 ]; then
             CMD_ARGS+=(runner.parallel.cluster=slurm)
         fi

--- a/workflow/rules/inference.smk
+++ b/workflow/rules/inference.smk
@@ -255,7 +255,7 @@ rule execute_inference:
 
         # is GPU > 1, add runner=parallel to CMD_ARGS
         if [ {resources.gpus} -gt 1 ]; then
-            CMD_ARGS+=(runner=parallel)
+            CMD_ARGS+=(runner.parallel.cluster=slurm)
         fi
 
         srun \


### PR DESCRIPTION
In our case, we can safely assume we'll be running on a slurm cluster and avoid any issue with the automatic cluster selection, see https://github.com/ecmwf/anemoi-inference/issues/407