### PR TITLE
Mrb 521 add config to experiment report

### DIFF
--- a/resources/report/dashboard/template.html.jinja2
+++ b/resources/report/dashboard/template.html.jinja2
@@ -141,7 +141,6 @@
 
     <!-- Config file tab -->
     <div id="tab_config" class="tab-content">
-        <h3>Config: {{ configfile_path if configfile_path and configfile_content else '' }}</h3>
         <pre style="background:#f7f7f7; border:1px solid #ddd; padding:1em; overflow-x:auto; max-height:60vh;">
 {{ configfile_content | e }}
         </pre>

--- a/resources/report/dashboard/template.html.jinja2
+++ b/resources/report/dashboard/template.html.jinja2
@@ -94,13 +94,13 @@
 
     <div class="header">
         <div class="tab-buttons">
-            <button class="tab-link active" data-tab="tab1">Standard verification</button>
-            <button class="tab-link" data-tab="tab2">Diagnostic verification</button>
+            <button class="tab-link active" data-tab="tab_scores">Standard verification</button>
+            <button class="tab-link" data-tab="tab_config">Config file</button>
         </div>
     </div>
 
     <!-- First tab -->
-    <div id="tab1" class="tab-content active">
+    <div id="tab_scores" class="tab-content active">
         <div class="controls">
             <div class="control-group">
                 <label>Region</label>
@@ -139,8 +139,13 @@
     </div>
 
 
-    <!-- Second tab -->
-    <div id="tab2" class="tab-content">Coming soon...</div>
+    <!-- Config file tab -->
+    <div id="tab_config" class="tab-content">
+        <h3>Config: {{ configfile_path if configfile_path and configfile_content else '' }}</h3>
+        <pre style="background:#f7f7f7; border:1px solid #ddd; padding:1em; overflow-x:auto; max-height:60vh;">
+{{ configfile_content | e }}
+        </pre>
+    </div>
 
 
     <script id="verif-data" type="application/json">

--- a/resources/report/dashboard/template.html.jinja2
+++ b/resources/report/dashboard/template.html.jinja2
@@ -95,7 +95,7 @@
     <div class="header">
         <div class="tab-buttons">
             <button class="tab-link active" data-tab="tab_scores">Standard verification</button>
-            <button class="tab-link" data-tab="tab_config">Config file</button>
+            <button class="tab-link" data-tab="tab_config">Config</button>
         </div>
     </div>
 

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -21,6 +21,7 @@ rule report_experiment_dashboard:
         verif=EXPERIMENT_PARTICIPANTS.values(),
         template="resources/report/dashboard/template.html.jinja2",
         js_script="resources/report/dashboard/script.js",
+        configfile={workflow.configfiles[0]},
     output:
         report(
             directory(OUT_ROOT / "results/{experiment}/metrics/dashboard"),
@@ -38,5 +39,6 @@ rule report_experiment_dashboard:
             --template {input.template} \
             --script {input.js_script} \
             --header_text "{params.header_text}" \
+            --configfile "{input.configfile}" \
             --output {output} > {log} 2>&1
         """

--- a/workflow/scripts/report_experiment_dashboard.py
+++ b/workflow/scripts/report_experiment_dashboard.py
@@ -79,6 +79,8 @@ def main(args):
         metrics=metrics,
         regions=regions,
         header_text=args.header_text,
+        configfile_path=args.configfile,
+        configfile_content=open(args.configfile, "r").read(),
     )
     LOG.info("Size of generated HTML: %d bytes", len(html.encode("utf-8")))
 
@@ -115,6 +117,11 @@ if __name__ == "__main__":
         type=str,
         default="",
         help="Text to display in the header of the dashboard.",
+    )
+    parser.add_argument(
+        "--configfile",
+        type=Path,
+        help="Path to config file for the evalml run.",
     )
     parser.add_argument(
         "--output",

--- a/workflow/scripts/report_experiment_dashboard.py
+++ b/workflow/scripts/report_experiment_dashboard.py
@@ -79,8 +79,9 @@ def main(args):
         metrics=metrics,
         regions=regions,
         header_text=args.header_text,
-        configfile_path=args.configfile,
-        configfile_content=open(args.configfile, "r").read(),
+        configfile_content=open(args.configfile, "r").read()
+        if args.configfile.is_file()
+        else "",
     )
     LOG.info("Size of generated HTML: %d bytes", len(html.encode("utf-8")))
 


### PR DESCRIPTION
To improve reproducibility of evalml runs, we include the evalml config in the dashboard.

<img width="1150" height="425" alt="image" src="https://github.com/user-attachments/assets/67fc78b1-7344-4dfc-8350-4d0c9c633cfe" />


## Changes
* additional argument in report rule to pass configfile path
* parsed configfile in dashboard template

