### PR TITLE
Support for ICON 1km model

### DIFF
--- a/config/forecasters-ich1.yaml
+++ b/config/forecasters-ich1.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=../workflow/tools/config.schema.json
+description: |
+  Evaluate skill of COSMO-E emulator (M-1 forecaster).
+
+dates:
+  - 2020-02-03T00:00 # Storm Petra
+  - 2020-02-07T00:00 # Storm Sabine
+  - 2020-10-01T00:00 # Storm Brigitte
+
+runs:
+  - forecaster:
+      mlflow_id: b30acf68520a4bbd8324c44666561696
+      label: stage_C_icon_1km
+      steps: 0/120/6
+      config: resources/inference/configs/sgm-forecaster-global-ich1.yaml
+      disable_local_eccodes_definitions: true
+      extra_dependencies:
+        - git+https://github.com/ecmwf/anemoi-inference.git@main
+
+baselines: [] # TODO: add ICON-CH1-EPS baseline when available
+
+analysis:
+  label: REA-L-CH1
+  analysis_zarr: /store_new/mch/msopr/ml/datasets/mch-realch1-fdb-1km-2005-2025-1h-pl13-v1.0.zarr
+
+stratification:
+  regions:
+    - jura
+    - mittelland
+    - voralpen
+    - alpennordhang
+    - innerealpentaeler
+    - alpensuedseite
+  root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
+
+locations:
+  output_root: output/
+  mlflow_uri:
+    - https://servicedepl.meteoswiss.ch/mlstore
+    - https://mlflow.ecmwf.int
+
+profile:
+  executor: slurm
+  global_resources:
+    gpus: 16
+  default_resources:
+    slurm_partition: "postproc"
+    cpus_per_task: 1
+    mem_mb_per_cpu: 1800
+    runtime: "1h"
+    gpus: 0
+  jobs: 50

--- a/resources/inference/configs/sgm-forecaster-global-ich1.yaml
+++ b/resources/inference/configs/sgm-forecaster-global-ich1.yaml
@@ -1,0 +1,45 @@
+lead_time: 120h
+write_initial_state: true
+allow_nans: true
+
+env:
+  ANEMOI_INFERENCE_NUM_CHUNKS: 8 # OOM error if not set
+
+# inputs
+input:
+  test:
+    use_original_paths: true
+
+
+# outputs
+output:
+  tee:
+    - grib:
+        path: grib/{date}{time:04}_{step:03}.grib
+        encoding:
+          typeOfGeneratingProcess: 2
+        templates:
+          - file:
+              path: resources/icon-ch1-typeOfLevel=surface.grib
+              variables: [lsm, msl, sp, z, skt, tp]
+          - file:
+              path: resources/icon-ch1-typeOfLevel=heightAboveGround.grib
+              variables: [2t, 2d, 10u, 10v]
+          - file: resources/icon-ch1-typeOfLevel=isobaricInhPa.grib
+        post_processors:
+          - extract_mask: # removes global points
+              mask: "lam_0/cutout_mask"
+              as_slice: true
+    - grib:
+        path: grib/ifs-{date}{time:04}_{step:03}.grib
+        encoding:
+          typeOfGeneratingProcess: 2
+        templates:
+          samples: resources/templates_index_ifs.yaml
+        post_processors:
+        - extract_mask: # removes lam points
+            mask: "lam_0/cutout_mask"
+            as_slice: true
+            inverse: true
+        - assign_mask: # fill local/global overlapping points with nan
+            mask: "global/cutout_mask"

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -90,6 +90,11 @@ class RunConfig(BaseModel):
         description="Resource requirements for inference jobs (optional; defaults handled externally).",
     )
 
+    disable_local_eccodes_definitions: bool = Field(
+        False,
+        description="If true, the ECCODES_DEFINITION_PATH environment variable will not be set to the COSMO local definitions.",
+    )
+
     config: Dict[str, Any] | str
 
     @field_validator("steps")

--- a/src/verification/__init__.py
+++ b/src/verification/__init__.py
@@ -74,7 +74,6 @@ class ShapefileSpatialAggregationMasks(SpatialAggregationMasks):
 def _compute_scores(
     fcst: xr.DataArray,
     obs: xr.DataArray,
-    dim=["x", "y"],
     prefix="",
     suffix="",
     source="",
@@ -83,6 +82,7 @@ def _compute_scores(
     Compute basic verification metrics between two xarray DataArrays (fcst and obs).
     Returns a xarray Dataset with the computed metrics.
     """
+    dim = ["x", "y"] if "x" in fcst.dims and "y" in fcst.dims else ["cell"]
     error = fcst - obs
     scores = xr.Dataset(
         {
@@ -100,7 +100,6 @@ def _compute_scores(
 
 def _compute_statistics(
     data: xr.DataArray,
-    dim=["x", "y"],
     prefix="",
     suffix="",
     source="",
@@ -109,6 +108,7 @@ def _compute_statistics(
     Compute basic statistics of a xarray DataArray (data).
     Returns a xarray Dataset with the computed statistics.
     """
+    dim = ["x", "y"] if "x" in data.dims and "y" in data.dims else ["cell"]
     stats = xr.Dataset(
         {
             f"{prefix}mean{suffix}": data.mean(dim=dim, skipna=True),

--- a/workflow/rules/inference.smk
+++ b/workflow/rules/inference.smk
@@ -232,6 +232,9 @@ rule execute_inference:
         workdir=lambda wc: (
             OUT_ROOT / f"data/runs/{wc.run_id}/{wc.init_time}"
         ).resolve(),
+        disable_local_definitions=lambda wc: RUN_CONFIGS[wc.run_id].get(
+            "disable_local_eccodes_definitions", False
+        ),
     resources:
         slurm_partition=lambda wc: get_resource(wc, "slurm_partition", "short-shared"),
         cpus_per_task=lambda wc: get_resource(wc, "cpus_per_task", 24),
@@ -249,7 +252,10 @@ rule execute_inference:
 
         squashfs-mount {params.image_path}:/user-environment -- bash -c '
         source /user-environment/bin/activate
-        export ECCODES_DEFINITION_PATH=/user-environment/share/eccodes-cosmo-resources/definitions
+
+        if [ "{params.disable_local_definitions}" = "False" ]; then
+            export ECCODES_DEFINITION_PATH=/user-environment/share/eccodes-cosmo-resources/definitions
+        fi
 
         CMD_ARGS=()
 

--- a/workflow/scripts/verif_single_init.py
+++ b/workflow/scripts/verif_single_init.py
@@ -97,7 +97,11 @@ def main(args: ScriptConfig):
                 params=args.params,
             )
             .compute()
-            .chunk({"y": -1, "x": -1})
+            .chunk(
+                {"y": -1, "x": -1}
+                if "y" in fcst.dims and "x" in fcst.dims
+                else {"cell": -1}
+            )
         )
     else:
         raise ValueError("--analysis_zarr must be provided.")

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -191,6 +191,12 @@
           "default": null,
           "description": "Resource requirements for inference jobs (optional; defaults handled externally)."
         },
+        "disable_local_eccodes_definitions": {
+          "default": false,
+          "description": "If true, the ECCODES_DEFINITION_PATH environment variable will not be set to the COSMO local definitions.",
+          "title": "Disable Local Eccodes Definitions",
+          "type": "boolean"
+        },
         "config": {
           "anyOf": [
             {
@@ -371,6 +377,12 @@
           ],
           "default": null,
           "description": "Resource requirements for inference jobs (optional; defaults handled externally)."
+        },
+        "disable_local_eccodes_definitions": {
+          "default": false,
+          "description": "If true, the ECCODES_DEFINITION_PATH environment variable will not be set to the COSMO local definitions.",
+          "title": "Disable Local Eccodes Definitions",
+          "type": "boolean"
         },
         "config": {
           "anyOf": [


### PR DESCRIPTION
This PR adds basic support for running checkpoints trained on the 1km ICON reanalysis light (REA-L-CH1) dataset.

### Summary of changes
- added new base anemoi-inference config for running the model
- added new example evalml config for running experiment or showcase 
- added option to disable eccodes local definitions
- minor fixes to source code to support unstructured grid (we need a proper refactoring at some point here) 

### Additional work
Importantly, some manual patching of the checkpoints was needed to ensure that we could write GRIB outputs. The patched metadata is this: [variables_metadata.yaml](https://github.com/user-attachments/files/24639596/variables_metadata.yaml). It makes sure that the variables metadata is present for all variables, and the `param` entry specified in the `mars` language follows the IFS naming convention, instead of MeteoSwiss' (related: https://github.com/ecmwf/anemoi-datasets/issues/332). For this reason, we also needed to disable ECCODES local definitions. 

### Known issues
In plots of meteorological fields, total precipitation appears all NaNs outside of the regional domain. This will be investigated separately.