### PR TITLE
Ignore git hashes for non-anemoi dependencies

### DIFF
--- a/workflow/scripts/set_inference_pyproject.py
+++ b/workflow/scripts/set_inference_pyproject.py
@@ -231,13 +231,10 @@ def get_other_versions(client: MlflowClient, run_id: str) -> dict:
     """
     versions = {}
     for dep in OTHER_DEPENDENCIES:
-        version, commit_hash = get_version_and_commit_hash(client, run_id, dep)
-        if not version and not commit_hash:
+        version, _ = get_version_and_commit_hash(client, run_id, dep)
+        if not version:
             logger.warning("No commit or version found for %s", dep)
             continue
-        if commit_hash:
-            logger.info("Found commit %s for %s", commit_hash, dep)
-            ref = resolve_dependency_config(commit_hash, dep)
         else:
             logger.info("Using version %s for %s", version, dep)
             ref = version


### PR DESCRIPTION
There is an issue with how git hashes are specified as versions for the dependencies in the MLFlow logs. All libraries seem to have the same git hash which does not make sense. As an urgent hot fix, we simply ignore the git hash for non-anemoi dependencies, since typically the actual release version is provided anyway. 