### PR TITLE
Use new config entry for checkpoint path

### DIFF
--- a/workflow/scripts/set_inference_pyproject.py
+++ b/workflow/scripts/set_inference_pyproject.py
@@ -278,7 +278,12 @@ def get_path_to_checkpoints(client: MlflowClient, run_id: str) -> str:
         ValueError: If no valid checkpoints path is found
     """
     run = client.get_run(run_id)
+
+    # for legacy runs
     path = run.data.params.get("config.hardware.paths.checkpoints")
+
+    # for newer runs
+    path = path or run.data.params.get("config.system.output.checkpoints.root")
 
     if not path:
         raise ValueError("No valid checkpoints path found in MLflow run")


### PR DESCRIPTION
https://github.com/ecmwf/anemoi-core/pull/598 changed the way we can access the checkpoint path from the MLFLow logged parameter, so we need to support both the new config and the old one for backwards compatibility.