### PR TITLE
Fix parsing of module versions in provenance metadata

### DIFF
--- a/workflow/scripts/inference_get_requirements.py
+++ b/workflow/scripts/inference_get_requirements.py
@@ -112,14 +112,26 @@ def extract_pypi_requirements(
     """
     requirements: dict[str, str] = {}
 
-    for module, version_str in module_versions.items():
-        if module.startswith("_"):
+    for module, version_info in module_versions.items():
+        if module.startswith("_") or not version_info:
             continue
-        if not version_str or not version_str[0].isdigit():
+
+        if isinstance(version_info, str):  # backwards compatibility
+            version = version_info
+        elif isinstance(
+            version_info, dict
+        ):  # https://github.com/ecmwf/anemoi-utils/commit/b28a62b3a0da6382449362132cdc000efc39ce5d
+            version = version_info.get("version")
+        else:
+            raise ValueError(
+                f"Unexpected module version info. Expected a string or dict containing a 'version' key, got {type(version_info)}"
+            )
+
+        if not version[0].isdigit():
             continue
 
         try:
-            version = Version(version_str)
+            version = Version(version)
         except InvalidVersion:
             continue
 


### PR DESCRIPTION
This pull request updates the `extract_pypi_requirements` function in `workflow/scripts/inference_get_requirements.py` to improve support different formats for module version information. The main change is to support both string (legacy) and dictionary (new) formats for module versions. The latter was introduced in https://github.com/ecmwf/anemoi-utils/pull/268 - a breaking change that we missed. 

This fix is required to run latest checkpoints from @icedoom888. 