### PR TITLE
Add wildcard constraint to 'showcase' to fix KeyError after #122

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -37,6 +37,13 @@ LOGS_DIR = OUT_ROOT / "logs"
 RESULTS_DIR = OUT_ROOT / "results" / EXPERIMENT_NAME
 
 
+# Since run_id now contains "/" (format: "{env_id}/{r_hash}"), Snakemake wildcards
+# would greedily absorb part of run_id into {showcase} when matching paths of the
+# form results/{showcase}/{run_id}/... — constrain showcase to a single path component.
+wildcard_constraints:
+    showcase=r"[^/]+",
+
+
 # optional messages, log and error handling
 # -----------------------------------------------------
 

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -34,6 +34,8 @@ rule plot_meteogram:
     output:
         OUT_ROOT
         / "results/{showcase}/{run_id}/{init_time}/{init_time}_{param}_{sta}.png",
+    wildcard_constraints:
+        showcase=r"[^/]+"  # without /
     # localrule: True
     resources:
         slurm_partition="postproc",
@@ -133,6 +135,8 @@ rule make_forecast_animation:
     output:
         OUT_ROOT
         / "results/{showcase}/{run_id}/{init_time}/{init_time}_{param}_{region}.gif",
+    wildcard_constraints:
+        showcase=r"[^/]+"  # without /
     params:
         delay=lambda wc: 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2]),
     shell:

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -34,8 +34,6 @@ rule plot_meteogram:
     output:
         OUT_ROOT
         / "results/{showcase}/{run_id}/{init_time}/{init_time}_{param}_{sta}.png",
-    wildcard_constraints:
-        showcase=r"[^/]+"  # without /
     # localrule: True
     resources:
         slurm_partition="postproc",
@@ -135,8 +133,6 @@ rule make_forecast_animation:
     output:
         OUT_ROOT
         / "results/{showcase}/{run_id}/{init_time}/{init_time}_{param}_{region}.gif",
-    wildcard_constraints:
-        showcase=r"[^/]+"  # without /
     params:
         delay=lambda wc: 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2]),
     shell:


### PR DESCRIPTION
fix from regression after #122 when running showcase workflow:
``` 
InputFunctionException in rule make_forecast_animation in file "/users/ned/src/evalml/workflow/rules/plot.smk", line 125:
Error:
  KeyError: '88a3'
Wildcards:
  showcase=20260401_forecasters-ich1_75e9/forecaster-233b-098c
  run_id=88a3
  init_time=202406010000
  param=T_2M
  region=globe
Traceback:
  File "/users/ned/src/evalml/workflow/rules/plot.smk", line 130, in <lambda>
  File "/users/ned/src/evalml/workflow/rules/plot.smk", line 118, in get_leadtimes (rule make_forecast_animation, line 207, /users/ned/src/evalml/workflow/rules/plot.smk)
 ```
run_id now contains "/" (format: "{env_id}/{r_hash}"), Snakemake wildcards would greedily absorb part of run_id into {showcase} when matching paths of the form results/{showcase}/{run_id}/... constrain showcase to a single path component.
