### PR TITLE
Support orographic forcings

### DIFF
--- a/resources/inference/metadata/sgm-ich1-oper-patch_metadata.yaml
+++ b/resources/inference/metadata/sgm-ich1-oper-patch_metadata.yaml
@@ -7,6 +7,20 @@ config:
           - dataset: /store_new/mch/msopr/ml/datasets/aifs-od-an-oper-0001-mars-n320-2016-2025-6h-v1-combined-land.zarr
 dataset:
   variables_metadata:
+    slor:
+      mars:
+        date: 20050101
+        levtype: sfc
+        param: SSO_SIGMA
+        step: 12
+        time: 0
+    sdor:
+      mars:
+        date: 20050101
+        levtype: sfc
+        param: SSO_STDH
+        step: 12
+        time: 0
     10u:
       mars:
         date: 20050101

--- a/resources/inference/metadata/sgm-ich1-patch_metadata.yaml
+++ b/resources/inference/metadata/sgm-ich1-patch_metadata.yaml
@@ -7,6 +7,20 @@ config:
           - dataset: /store_new/mch/msopr/ml/datasets/aifs-ea-an-oper-0001-mars-n320-1979-2024-6h-v1-for-single-v2.zarr
 dataset:
   variables_metadata:
+    slor:
+      mars:
+        date: 20050101
+        levtype: sfc
+        param: SSO_SIGMA
+        step: 12
+        time: 0
+    sdor:
+      mars:
+        date: 20050101
+        levtype: sfc
+        param: SSO_STDH
+        step: 12
+        time: 0
     10u:
       mars:
         date: 20050101

--- a/resources/inference/metadata/sgm-multidataset-ich1-oper-patch.yaml
+++ b/resources/inference/metadata/sgm-multidataset-ich1-oper-patch.yaml
@@ -14,6 +14,20 @@ config:
 dataset:
   data:
     variables_metadata:
+      slor:
+        mars:
+          date: 20050101
+          levtype: sfc
+          param: SSO_SIGMA
+          step: 12
+          time: 0
+      sdor:
+        mars:
+          date: 20050101
+          levtype: sfc
+          param: SSO_STDH
+          step: 12
+          time: 0
       10u:
         mars:
           date: 20050101

--- a/resources/inference/templates/templates_index_icon.yaml
+++ b/resources/inference/templates/templates_index_icon.yaml
@@ -6,7 +6,7 @@
 - - {levtype: sfc, param: [T_2M, TD_2M, U_10M, V_10M]}
   - resources/icon-ch1-typeOfLevel=heightAboveGround.grib
 
-- - {levtype: sfc, param: [FR_LAND, PS, FIS, T_G, SKT]}
+- - {levtype: sfc, param: [FR_LAND, PS, FIS, T_G, SKT, SSO_SIGMA,SSO_STDH]}
   - resources/icon-ch1-typeOfLevel=surface.grib
 
 - - {levtype: sfc, param: [PMSL]}


### PR DESCRIPTION
In some of the latest checkpoints, some orographic forcings were used. This broke inference for two reasons:

* the metadata patches did not include them
* the template index did not include them

This should be regarded as a hotfix, because there is a larger problem that all these configuration and patch files are hardcoded, so this will happen every time we add a new variable. I will open an issue for this.