### PR TITLE
Clean up ICON baseline datasets for verification

### DIFF
--- a/config/forecasters-ich1-oper-fixed.yaml
+++ b/config/forecasters-ich1-oper-fixed.yaml
@@ -34,7 +34,7 @@ runs:
 baselines:
   - baseline:
       label: ICON-CH1-EPS
-      root: /scratch/mch/cmerker/ICON-CH1-EPS
+      root: /store_new/mch/msopr/ml/ICON-CH1-EPS
       steps: 0/33/6
 
 truth:

--- a/config/forecasters-ich1-oper.yaml
+++ b/config/forecasters-ich1-oper.yaml
@@ -24,12 +24,12 @@ runs:
 
   - baseline:
       label: ICON-CH1-ctrl
-      root: /scratch/mch/cmerker/ICON-CH1-EPS
+      root: /store_new/mch/msopr/ml/ICON-CH1-EPS
       steps: 0/33/6
 
   - baseline:
       label: ICON-CH2-ctrl
-      root: /scratch/mch/cmerker/ICON-CH2-EPS
+      root: /store_new/mch/msopr/ml/ICON-CH2-EPS
       steps: 0/120/6
 
 truth:

--- a/config/forecasters-ich1.yaml
+++ b/config/forecasters-ich1.yaml
@@ -41,7 +41,7 @@ runs:
 
   - baseline:
       label: ICON-CH2-EPS
-      root: /scratch/mch/cmerker/ICON-CH2-EPS
+      root: /store_new/mch/msopr/ml/ICON-CH2-EPS
       steps: 0/120/6
 
 truth:


### PR DESCRIPTION
This PR replaces the patched ICON datasets in /scratch/mch/cmerker with the fixed datasets in /store_new/mch/msopr/ml