### PR TITLE
Keep _is_candidate=True if the run was already registered

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -176,7 +176,13 @@ def collect_all_runs() -> dict:
         if model_type == "baseline":
             continue
         run_config = run_entry[model_type]
-        runs |= register_run(model_type, run_config)
+        for run_id, run_cfg in register_run(model_type, run_config).items():
+            if run_id in runs and runs[run_id].get("_is_candidate", False):
+                # Preserve candidates by not letting a dependency registration
+                # (as_candidate=False) demote a run that was already registered as
+                # an explicit candidate. Order in config["runs"] must not matter.
+                run_cfg["_is_candidate"] = True
+            runs[run_id] = run_cfg
     return runs
 
 


### PR DESCRIPTION
`runs |= register_run(...)` would silently overwrite any existing entry, including the `_is_candidate` flag. When a forecaster appeared before the interpolator that depends on it, the interpolator's recursive registration (with `as_candidate=False`) would clobber the forecaster's already-set True.

The fix iterates the new entries individually and keeps `_is_candidate=True` if the run was already registered as an explicit candidate, regardless of config order.