### PR TITLE
Configurable Stratification

### DIFF
--- a/config/forecasters-co1e.yaml
+++ b/config/forecasters-co1e.yaml
@@ -39,6 +39,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - init_hour
+    # - region
+    - season
+
 locations:
   output_root: output/
 

--- a/config/forecasters-co2-disentangled.yaml
+++ b/config/forecasters-co2-disentangled.yaml
@@ -60,6 +60,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - init_hour
+    # - region
+    - season
+
 locations:
   output_root: output/
 

--- a/config/forecasters-co2.yaml
+++ b/config/forecasters-co2.yaml
@@ -35,6 +35,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - init_hour
+    # - region
+    - season
+
 locations:
   output_root: output/
 

--- a/config/forecasters-ich1-oper-fixed.yaml
+++ b/config/forecasters-ich1-oper-fixed.yaml
@@ -51,6 +51,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - init_hour
+    # - region
+    - season
+
 locations:
   output_root: output/
 

--- a/config/forecasters-ich1-oper.yaml
+++ b/config/forecasters-ich1-oper.yaml
@@ -46,6 +46,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - init_hour
+    # - region
+    - season
+
 locations:
   output_root: output/
 

--- a/config/forecasters-ich1.yaml
+++ b/config/forecasters-ich1.yaml
@@ -58,6 +58,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - init_hour
+    # - region
+    - season
+
 locations:
   output_root: output/
 

--- a/config/interpolators-co2.yaml
+++ b/config/interpolators-co2.yaml
@@ -66,6 +66,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - init_hour
+    # - region
+    - season
+
 locations:
   output_root: output/
 

--- a/config/interpolators-ich1.yaml
+++ b/config/interpolators-ich1.yaml
@@ -55,6 +55,12 @@ stratification:
     - alpensuedseite
   root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
 
+dashboard:
+  stratification:
+    # - region
+    # - init_hour
+    - season
+
 locations:
   output_root: output/
 

--- a/resources/report/dashboard/script.js
+++ b/resources/report/dashboard/script.js
@@ -12,32 +12,24 @@ document.querySelectorAll(".tab-link").forEach(button => {
 // Initialize selection widgets
 const choicesInstances = {};
 
-choicesInstances["region-select"] = new Choices("#region-select", {
+const choicesConfig = {
   searchEnabled: false,
   removeItemButton: true,
   shouldSort: false,
   itemSelectText: "",
   placeholder: false
-});
-document.getElementById("region-select").addEventListener("change", updateChart);
+};
 
-choicesInstances["season-select"] = new Choices("#season-select", {
-  searchEnabled: false,
-  removeItemButton: true,
-  shouldSort: false,
-  itemSelectText: "",
-  placeholder: false
-});
-document.getElementById("season-select").addEventListener("change", updateChart);
+function initChoices(id) {
+  if (document.getElementById(id)) {
+    choicesInstances[id] = new Choices("#" + id, choicesConfig);
+    document.getElementById(id).addEventListener("change", updateChart);
+  }
+}
 
-choicesInstances["init-select"] = new Choices("#init-select", {
-  searchEnabled: false,
-  removeItemButton: true,
-  shouldSort: false,
-  itemSelectText: "",
-  placeholder: false
-});
-document.getElementById("init-select").addEventListener("change", updateChart);
+initChoices("region-select");
+initChoices("season-select");
+initChoices("init-select");
 
 choicesInstances["source-select"] = new Choices("#source-select", {
   searchEnabled: false,
@@ -146,9 +138,9 @@ function getSelectedValues(id) {
 }
 
 function updateChart() {
-  const selectedRegions = getSelectedValues("region-select");
-  const selectedSeasons = getSelectedValues("season-select");
-  const selectedInits = getSelectedValues("init-select");
+  const selectedRegions = choicesInstances["region-select"] ? getSelectedValues("region-select") : [];
+  const selectedSeasons = choicesInstances["season-select"] ? getSelectedValues("season-select") : [];
+  const selectedInits = choicesInstances["init-select"] ? getSelectedValues("init-select") : [];
   const selectedSources = getSelectedValues("source-select");
   const selectedparams = getSelectedValues("param-select");
   const selectedMetrics = getSelectedValues("metric-select");

--- a/resources/report/dashboard/template.html.jinja2
+++ b/resources/report/dashboard/template.html.jinja2
@@ -102,6 +102,7 @@
     <!-- First tab -->
     <div id="tab_scores" class="tab-content active">
         <div class="controls">
+            {% if 'region' in stratification %}
             <div class="control-group">
                 <label>Region</label>
                 <select id="region-select" multiple>
@@ -110,6 +111,8 @@
                     {% endfor %}
                 </select>
             </div>
+            {% endif %}
+            {% if 'season' in stratification %}
             <div class="control-group">
                 <label>Season</label>
                 <select id="season-select" multiple>
@@ -118,6 +121,8 @@
                     {% endfor %}
                 </select>
             </div>
+            {% endif %}
+            {% if 'init_hour' in stratification %}
             <div class="control-group">
                 <label>Initialization</label>
                 <select id="init-select" multiple>
@@ -126,6 +131,7 @@
                     {% endfor %}
                 </select>
             </div>
+            {% endif %}
             <div class="control-group">
                 <label>Source(s)</label>
                 <select id="source-select" multiple>
@@ -172,6 +178,7 @@
     </script>
 
     <script>
+        const activeStratifications = {{ stratification | tojson }};
         {{ js_src | indent(8, true) }}
     </script>
 </body>

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -227,6 +227,15 @@ class Stratification(BaseModel):
     )
 
 
+class Dashboard(BaseModel):
+    """Settings for the dashboard"""
+
+    stratification: List[str] = Field(
+        ...,
+        description="Stratifications to include in the dashboard (any of season, region, init_hour)",
+    )
+
+
 class DefaultResources(BaseModel):
     """Default resource settings for job execution."""
 
@@ -316,6 +325,7 @@ class ConfigModel(BaseModel):
     )
     truth: TruthConfig | None
     stratification: Stratification
+    dashboard: Dashboard
     locations: Locations
     profile: Profile
 

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -31,6 +31,7 @@ rule report_experiment_dashboard:
     params:
         sources=",".join(list(EXPERIMENT_PARTICIPANTS.keys())),
         header_text=make_header_text(),
+        stratification=" ".join(config["dashboard"]["stratification"]),
     log:
         OUT_ROOT / "logs/report_experiment_dashboard/{experiment}.log",
     shell:
@@ -41,5 +42,6 @@ rule report_experiment_dashboard:
             --script {input.js_script} \
             --header_text "{params.header_text}" \
             --configfile "{input.configfile}" \
+            --stratification {params.stratification} \
             --output {output} > {log} 2>&1
         """

--- a/workflow/scripts/report_experiment_dashboard.py
+++ b/workflow/scripts/report_experiment_dashboard.py
@@ -47,6 +47,16 @@ def main(args):
     # convert numeric column init_hour to string in format HH:00 UTC and replace -999 with "all"
     df["init_hour"] = df["init_hour"].astype(str).str.zfill(2) + ":00 UTC"
     df["init_hour"] = df["init_hour"].where(df["init_hour"] != "-999:00 UTC", "all")
+
+    # retain only rows relevant for the active stratifications
+    stratification = args.stratification
+    if "region" not in stratification:
+        df = df[df["region"] == "all"]
+    if "season" not in stratification:
+        df = df[df["season"] == "all"]
+    if "init_hour" not in stratification:
+        df = df[df["init_hour"] == "all"]
+
     # create a new column for line styles and shapes in dashboard
     df["region_season_init"] = (
         "Region: "
@@ -64,9 +74,9 @@ def main(args):
     sources = df["source"].unique()
     params = df["param"].unique()
     metrics = df["metric"].unique()
-    regions = df["region"].unique()
-    seasons = df["season"].unique()
-    init_hours = df["init_hour"].unique()
+    regions = df["region"].unique() if "region" in stratification else []
+    seasons = df["season"].unique() if "season" in stratification else []
+    init_hours = df["init_hour"].unique() if "init_hour" in stratification else []
 
     # get json string to embed in the HTML
     df_json = df.to_json(orient="records", lines=False)
@@ -93,6 +103,7 @@ def main(args):
         regions=regions,
         seasons=seasons,
         init_hours=init_hours,
+        stratification=stratification,
         header_text=args.header_text,
         configfile_content=open(args.configfile, "r").read()
         if args.configfile.is_file()
@@ -133,6 +144,12 @@ if __name__ == "__main__":
         type=str,
         default="",
         help="Text to display in the header of the dashboard.",
+    )
+    parser.add_argument(
+        "--stratification",
+        nargs="*",
+        default=["region", "season", "init_hour"],
+        help="Stratification dimensions to include in the dashboard (any of region, season, init_hour).",
     )
     parser.add_argument(
         "--configfile",

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -56,6 +56,24 @@
       "title": "BaselineItem",
       "type": "object"
     },
+    "Dashboard": {
+      "description": "Settings for the dashboard",
+      "properties": {
+        "stratification": {
+          "description": "Stratifications to include in the dashboard (any of season, region, init_hour)",
+          "items": {
+            "type": "string"
+          },
+          "title": "Stratification",
+          "type": "array"
+        }
+      },
+      "required": [
+        "stratification"
+      ],
+      "title": "Dashboard",
+      "type": "object"
+    },
     "Dates": {
       "description": "Start/stop of the hindcast period and the launch frequency.",
       "properties": {
@@ -584,6 +602,9 @@
     "stratification": {
       "$ref": "#/$defs/Stratification"
     },
+    "dashboard": {
+      "$ref": "#/$defs/Dashboard"
+    },
     "locations": {
       "$ref": "#/$defs/Locations"
     },
@@ -597,6 +618,7 @@
     "runs",
     "truth",
     "stratification",
+    "dashboard",
     "locations",
     "profile"
   ],


### PR DESCRIPTION
**Please note: all of the changes implemented in this PR only affect the dashboard. The underlying verification files are untouched (i.e. still include the full stratification).**

## Changes
* add a new dashboard section to the main config
* allow users to omit stratifications from the dashboard to keep dashboard size manageable
* example config `interpolators-ich1.ymal` with seasonal stratification only reduces the size of the dashboard from 138 Mb to 9 Mb
* drop-downs are only shown for stratifications that are available, but all stratifications are indicated on the plot (see screen shot below)

<img width="1150" height="537" alt="image" src="https://github.com/user-attachments/assets/80252502-e511-4a99-becc-3f66f7ca6275" />