### PR TITLE
Blacklist of forecast initializations

### DIFF
--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -22,6 +22,10 @@ class Dates(BaseModel):
         description="Time between initialisations. Must be a combination of a number and a time unit (h or d).",
         pattern=r"^\d+[hd]$",
     )
+    blacklist: List[str] = Field(
+        default_factory=list,
+        description="Optional list of initialisation dates (ISO-8601) to exclude from processing.",
+    )
 
 
 class ExplicitDates(RootModel[List[str]]):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -64,10 +64,14 @@ def parse_reference_times():
     start = datetime.strptime(cfg["start"], DATETIME_FORMAT)
     end = datetime.strptime(cfg["end"], DATETIME_FORMAT)
     freq = parse_timedelta(cfg["frequency"])
+    blacklist = {
+        datetime.strptime(t, DATETIME_FORMAT) for t in cfg.get("blacklist", [])
+    }
     times = []
     t = start
     while t <= end:
-        times.append(t)
+        if t not in blacklist:
+            times.append(t)
         t += freq
     return times
 

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -12,7 +12,11 @@ def make_header_text():
     truth = config["truth"]["label"]
     if isinstance(dates, list):
         return f"Explicit initializations from {len(dates)} runs have been used."
-    return f"Verification against {truth} with initializations from {dates.get('start')} to {dates.get('end')} by {dates.get('frequency')}"
+    text = f"Verification against {truth} with initializations from {dates.get('start')} to {dates.get('end')} by {dates.get('frequency')}"
+    blacklist = dates.get("blacklist", [])
+    if blacklist:
+        text += f" (excluding {len(blacklist)} blacklisted date{'s' if len(blacklist) != 1 else ''})"
+    return text
 
 
 rule report_experiment_dashboard:

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -15,7 +15,7 @@ def make_header_text():
     text = f"Verification against {truth} with initializations from {dates.get('start')} to {dates.get('end')} by {dates.get('frequency')}"
     blacklist = dates.get("blacklist", [])
     if blacklist:
-        text += f" (excluding {len(blacklist)} blacklisted date{'s' if len(blacklist) != 1 else ''})"
+        text += f" (excluding {len(blacklist)} blacklisted date{'s' if len(blacklist)!=1 else ''})"
     return text
 
 

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -92,6 +92,14 @@
           "pattern": "^\\d+[hd]$",
           "title": "Frequency",
           "type": "string"
+        },
+        "blacklist": {
+          "description": "Optional list of initialisation dates (ISO-8601) to exclude from processing.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Blacklist",
+          "type": "array"
         }
       },
       "required": [


### PR DESCRIPTION
When running experiments with many initialization times, sometime individual initializations do not run successfully due to data problems. In order to deal with this problem, a blacklist of initialization times can be provided in the config to exclude from experiments.

## Summary of Changes
* adapted config schema and update generation of list of initialization times
* provide one example config with a blacklisted initialization