### PR TITLE
Retain sample size for further aggregation of strata

### DIFF
--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1,4 +1,12 @@
+import sys
+from pathlib import Path
+
+import numpy as np
 import pytest
+import xarray as xr
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "workflow" / "scripts"))
+from verification_aggregation import aggregate_results
 
 from verification import decode_metric
 
@@ -22,3 +30,65 @@ from verification import decode_metric
 )
 def test_decode_metric(label, expected):
     assert decode_metric(label) == expected
+
+
+def _make_verif_dataset(ref_times):
+    """Minimal verification dataset with a single continuous metric."""
+    n = len(ref_times)
+    return xr.Dataset(
+        {"T_2M.BIAS": (["ref_time", "region", "source"], np.ones((n, 1, 1)))},
+        coords={
+            "ref_time": ref_times,
+            "region": ["all"],
+            "source": ["fcst"],
+        },
+    )
+
+
+def test_aggregate_results_n_samples_global():
+    ref_times = np.array(
+        ["2024-01-01T00", "2024-04-01T00", "2024-07-01T00", "2024-10-01T00"],
+        dtype="datetime64[ns]",
+    )
+    out = aggregate_results(_make_verif_dataset(ref_times))
+
+    assert "n_samples" in out.data_vars
+    assert int(out["n_samples"].sel(season="all", init_hour=-999)) == 4
+
+
+def test_aggregate_results_n_samples_by_season():
+    # 2 DJF (Jan), 1 MAM (Apr), 1 JJA (Jul)
+    ref_times = np.array(
+        ["2024-01-01T00", "2024-01-15T00", "2024-04-01T00", "2024-07-01T00"],
+        dtype="datetime64[ns]",
+    )
+    out = aggregate_results(_make_verif_dataset(ref_times))
+
+    assert int(out["n_samples"].sel(season="DJF", init_hour=-999)) == 2
+    assert int(out["n_samples"].sel(season="MAM", init_hour=-999)) == 1
+    assert int(out["n_samples"].sel(season="JJA", init_hour=-999)) == 1
+
+
+def test_aggregate_results_n_samples_by_init_hour():
+    # 3 times at 00Z, 1 time at 12Z
+    ref_times = np.array(
+        ["2024-01-01T00", "2024-04-01T00", "2024-07-01T00", "2024-10-01T12"],
+        dtype="datetime64[ns]",
+    )
+    out = aggregate_results(_make_verif_dataset(ref_times))
+
+    assert int(out["n_samples"].sel(season="all", init_hour=0)) == 3
+    assert int(out["n_samples"].sel(season="all", init_hour=12)) == 1
+
+
+def test_aggregate_results_n_samples_by_season_and_init_hour():
+    # DJF/00Z: 2, DJF/12Z: 1, JJA/00Z: 1
+    ref_times = np.array(
+        ["2024-01-01T00", "2024-01-15T00", "2024-01-20T12", "2024-07-01T00"],
+        dtype="datetime64[ns]",
+    )
+    out = aggregate_results(_make_verif_dataset(ref_times))
+
+    assert int(out["n_samples"].sel(season="DJF", init_hour=0)) == 2
+    assert int(out["n_samples"].sel(season="DJF", init_hour=12)) == 1
+    assert int(out["n_samples"].sel(season="JJA", init_hour=0)) == 1

--- a/workflow/scripts/verification_aggregation.py
+++ b/workflow/scripts/verification_aggregation.py
@@ -45,28 +45,39 @@ def aggregate_results(ds: xr.Dataset) -> xr.Dataset:
         init_hour=lambda ds: ds.ref_time.dt.hour,
     ).drop_vars(["time"], errors="ignore")
 
+    # Counter used to track the number of ref_time samples per stratum so that
+    # aggregated results can be correctly re-aggregated later (weighted mean).
+    n_counter = xr.DataArray(
+        np.ones(len(ds.ref_time), dtype=np.int64),
+        coords={c: ds[c] for c in ["ref_time", "season", "init_hour"]},
+        dims=["ref_time"],
+    )
+
     # compute mean with grouping by all permutations of season and init_hour
     ds_mean = []
     for group in [[], "season", "init_hour", ["season", "init_hour"]]:
         if group == []:
             ds_grouped = ds
+            n_grouped = n_counter.sum().compute()
         else:
             ds_grouped = ds.groupby(group)
-        ds_grouped = ds_grouped.mean(dim="ref_time").compute(
+            n_grouped = n_counter.groupby(group).sum().compute()
+        ds_result = ds_grouped.mean(dim="ref_time").compute(
             num_workers=4, scheduler="threads"
         )
+        ds_result["n_samples"] = n_grouped
         if "init_hour" not in group:
-            ds_grouped = ds_grouped.expand_dims({"init_hour": [-999]})
+            ds_result = ds_result.expand_dims({"init_hour": [-999]})
         if "season" not in group:
-            ds_grouped = ds_grouped.expand_dims({"season": ["all"]})
-        LOG.info("Aggregated by %s: \n %s", group, ds_grouped)
-        ds_mean.append(ds_grouped)
+            ds_result = ds_result.expand_dims({"season": ["all"]})
+        LOG.info("Aggregated by %s: \n %s", group, ds_result)
+        ds_mean.append(ds_result)
     out = xr.merge(ds_mean, compat="no_conflicts", join="outer")
 
     for var in out.data_vars:
         if "contingency_table" in var:
-            # convert contingency table elements to counts
-            out[var] = out[var] * len(ds["ref_time"])
+            # convert contingency table means back to per-stratum counts
+            out[var] = out[var] * out["n_samples"]
             contingency_manager = scores.categorical.BasicContingencyManager(
                 {
                     "tp_count": out[var].sel(contingency="tp_count"),


### PR DESCRIPTION
## Summary of changes
* retain a counter of samples for the different init_hour and season strata for further aggregation
* fix a bug in scaling of seasonal and per init_hour counts for the contingency table