### PR TITLE
Rename interpolator to temporal downscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dates:
   #   - 2020-01-05T00:00
 
 runs:
-  # Each item is either `forecaster`, `interpolator` or `baseline`
+  # Each item is either `forecaster`, `temporal_downscaler` or `baseline`
   - forecaster:
       # `checkpoint` may point to a supported MLflow run URL, a Hugging Face `.ckpt` URL, or a local checkpoint path.
       checkpoint: https://servicedepl.meteoswiss.ch/mlstore#/experiments/228/runs/2f962c89ff644ca7940072fa9cd088ec
@@ -61,10 +61,10 @@ runs:
       label: M-1 forecaster
       steps: 0/120/6
       config: resources/inference/configs/sgm-forecaster-global_trimedge.yaml
-  # An interpolator entry can optionally embed its driving forecaster config inline.
-  # - interpolator:
-  #     checkpoint: /path/to/interpolator.ckpt
-  #     label: My interpolator
+  # A temporal_downscaler entry can optionally embed its driving forecaster config inline.
+  # - temporal_downscaler:
+  #     checkpoint: /path/to/temporal_downscaler.ckpt
+  #     label: My temporal downscaler
   #     steps: 0/120/1
   #     forecaster:
   #       checkpoint: https://...
@@ -137,7 +137,7 @@ profile:
     plot_forecast_frame: 32
 ```
 
-The `runs` list accepts `forecaster`, `interpolator`, and `baseline` entries. For `dates`, you can either provide a `start` / `end` / `frequency` block as above or an explicit list of ISO timestamps for case-study style runs. Stratification, thresholds, dashboard, and scorecard settings are all grouped under the `experiment` key.
+The `runs` list accepts `forecaster`, `temporal_downscaler`, and `baseline` entries. For `dates`, you can either provide a `start` / `end` / `frequency` block as above or an explicit list of ISO timestamps for case-study style runs. Stratification, thresholds, dashboard, and scorecard settings are all grouped under the `experiment` key.
 
 You can then run it with:
 
@@ -218,7 +218,7 @@ Scripts live in `workflow/scripts/` and mirror the rule that calls them:
 
 Examples: `inference_prepare.py`, `verification_metrics.py`, `verification_aggregation.py`, `plot_forecast_frame.mo.py`.
 
-In some cases, a single script may be shared by more than one rule (e.g. `inference_prepare.py` is used by both `inference_prepare_forecaster` and `inference_prepare_interpolator`).
+In some cases, a single script may be shared by more than one rule (e.g. `inference_prepare.py` is used by both `inference_prepare_forecaster` and `inference_prepare_temporal_downscaler`).
 
 ### Log file paths
 

--- a/config/temporal-downscalers-ich1.yaml
+++ b/config/temporal-downscalers-ich1.yaml
@@ -81,7 +81,7 @@ experiment:
           - "T_2M:RMSE,R2,ETS"
           - "TOT_PREC:RMSE,R2,ETS"
       short_range:
-        baseline: ICON-CH1-ctrl
+        baseline: ICON-CH1-CTRL
         lead_times: "6/33/6"
         stratification: region
         variables:
@@ -90,7 +90,7 @@ experiment:
           - "T_2M:RMSE,R2,ETS"
           - "TOT_PREC:RMSE,R2,ETS"
       medium_range:
-        baseline: ICON-CH2-ctrl
+        baseline: ICON-CH2-CTRL
         lead_times: "24/120/24"
         stratification: region
         variables:
@@ -129,6 +129,7 @@ profile:
     mem_mb_per_cpu: 1800
     runtime: "1h"
     gpus: 0
+    account: s83
   jobs: 50
   batch_rules:
     plot_forecast_frame: 8

--- a/config/temporal-downscalers-ich1.yaml
+++ b/config/temporal-downscalers-ich1.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../workflow/tools/config.schema.json
 description: |
-  Evaluate skill of new time-interpolator (trained on ICON-REA-L, fine-tuned on KENDA-ICON-CH1)
+  Evaluate skill of new temporal downscaler (trained on ICON-REA-L, fine-tuned on KENDA-ICON-CH1)
   driven by ICON-CH1 stage_E forecaster with subgrid orography, using anemoi-inference patch from
   issue #482.
 
@@ -10,13 +10,13 @@ dates:
   frequency: 24h
 
 runs:
-  - interpolator:
+  - temporal_downscaler:
       # for checkpoints trained on a different HPC, using mlflow doesn't work due to difference in
       # paths, so we directly specify the checkpoint path here
       checkpoint: /store_new/mch/msopr/ml/tmp/inference-last.ckpt
       label: Varda-Single
       steps: 0/120/1
-      config: resources/inference/configs/sgm-interpolator-global_trimedge_multi.yaml
+      config: resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml
       forecaster:
         checkpoint: https://service.meteoswiss.ch/mlstore#/experiments/602/runs/c30490b6ba064e4db03b430f3a2595ad
         config: resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper.yaml

--- a/config/temporal-downscalers-ich1.yaml
+++ b/config/temporal-downscalers-ich1.yaml
@@ -10,7 +10,7 @@ dates:
 
 runs:
   - temporal_downscaler:
-      checkpoint: /scratch/mch/miccatta/ICON_interpolator_checkpoints/checkpoint_stage-C-interpolator-n320-6hto1h-reduced-variables/f9279244ed6f4c458597bdcf335ab36f/inference-last.ckpt
+      checkpoint: /scratch/mch/miccatta/ICON_interpolator_checkpoints/checkpoint_stage-C-interpolator-n320-6hto1h-reduced-variables/eb534e4c9ca5408e8b83ace2f268bb29/inference-last.ckpt
       label: Varda-Single
       steps: 0/120/1
       config: resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml

--- a/config/temporal-downscalers-ich1.yaml
+++ b/config/temporal-downscalers-ich1.yaml
@@ -10,7 +10,7 @@ dates:
 
 runs:
   - temporal_downscaler:
-      checkpoint: /scratch/mch/miccatta/ICON_interpolator_checkpoints/checkpoint_stage-C-interpolator-n320-6hto1h-reduced-variables/eb534e4c9ca5408e8b83ace2f268bb29/inference-last.ckpt
+      checkpoint: /scratch/mch/miccatta/ICON_interpolator_checkpoints/checkpoint_stage-C-interpolator-n320-6hto1h-reduced-variables/f9279244ed6f4c458597bdcf335ab36f/inference-last.ckpt
       label: Varda-Single
       steps: 0/120/1
       config: resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml

--- a/config/temporal-downscalers-ich1.yaml
+++ b/config/temporal-downscalers-ich1.yaml
@@ -1,8 +1,7 @@
 # yaml-language-server: $schema=../workflow/tools/config.schema.json
 description: |
-  Evaluate skill of new temporal downscaler (trained on ICON-REA-L, fine-tuned on KENDA-ICON-CH1)
-  driven by ICON-CH1 stage_E forecaster with subgrid orography, using anemoi-inference patch from
-  issue #482.
+  Evaluate skill of temporal downscaler driven by ICON-CH1 Stage E forecaster with
+  subgrid orography.
 
 dates:
   start: 2025-03-01T00:00
@@ -11,32 +10,27 @@ dates:
 
 runs:
   - temporal_downscaler:
-      # for checkpoints trained on a different HPC, using mlflow doesn't work due to difference in
-      # paths, so we directly specify the checkpoint path here
-      checkpoint: /store_new/mch/msopr/ml/tmp/inference-last.ckpt
+      checkpoint: /scratch/mch/miccatta/ICON_interpolator_checkpoints/checkpoint_stage-C-interpolator-n320-6hto1h-reduced-variables/f9279244ed6f4c458597bdcf335ab36f/inference-last.ckpt
       label: Varda-Single
       steps: 0/120/1
       config: resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml
+      extra_requirements:
+        - anemoi-datasets==0.5.35
+        # - anemoi-inference==0.11.0
       forecaster:
         checkpoint: https://service.meteoswiss.ch/mlstore#/experiments/602/runs/c30490b6ba064e4db03b430f3a2595ad
         config: resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper.yaml
         steps: 0/120/6
-        extra_requirements:
-          - git+https://github.com/ecmwf/anemoi-inference.git@e369b1a90313e9701db13f63364a467aa281cf36
-      extra_requirements:
-        - git+https://github.com/ecmwf/anemoi-inference.git@e369b1a90313e9701db13f63364a467aa281cf36
-        # pinned anemoi-datasets because of ecmwf/anemoi-utils#284, can be removed when fixed
-        - anemoi-datasets==0.5.35
   - baseline:
       label: INCA
       root: /store_new/mch/msclim/INCA
       steps: 0/6/1
   - baseline:
-      label: ICON-CH2-ctrl
+      label: ICON-CH2-CTRL
       root: /store_new/mch/msopr/osm/ICON-CH2-EPS
       steps: 0/120/1
   - baseline:
-      label: ICON-CH1-ctrl
+      label: ICON-CH1-CTRL
       root: /store_new/mch/msopr/osm/ICON-CH1-EPS
       steps: 0/33/1
 

--- a/resources/inference/configs/sgm-temporal-downscaler-global_trimedge.yaml
+++ b/resources/inference/configs/sgm-temporal-downscaler-global_trimedge.yaml
@@ -1,4 +1,4 @@
-runner: time_multi_interpolator
+runner: temporal_downscaler
 
 input:
   cutout:
@@ -6,8 +6,8 @@ input:
         grib:
           path: forecaster/20*
           pre_processors:
+            - extract_mask: "source0/trimedge_mask"
             - forward_transform_filter:
-                # does not have an effect if the interpolator does not use tp as prognostic variable
                 rescale:
                   scale: 0.001 # convert from kg m-2 to m
                   offset: 0
@@ -55,7 +55,9 @@ constant_forcings:
   test:
     use_original_paths: true
 
-patch_metadata: resources/sgm-interpolator-ich1-oper-patch.yaml
+patch_metadata:
+  dataset:
+    constant_fields: [z, lsm]
 
 post_processors:
   - accumulate_from_start_of_forecast: # accumulate tp from start of forecast
@@ -74,12 +76,13 @@ output:
         encoding:
           typeOfGeneratingProcess: 2
         templates:
-            samples: resources/templates_index_icon.yaml
+            samples: resources/templates_index_cosmo.yaml
         post_processors:
           - extract_mask: # removes global points
               mask: "lam_0/cutout_mask"
               as_slice: true
-          # here, the trimedge mask can be specified when available
+          - assign_mask:  # fill boundary "trimmed" points with nan
+              mask: "source0/trimedge_mask"
 
     - grib:
         path: grib/ifs-{dateTime}_{step:03}.grib
@@ -125,7 +128,6 @@ output:
                 "^w_(\\d+)$": {"param": 135, "shortName": "w"}
                 "^z_(\\d+)$": {"param": 129, "shortName": "z"}
 
-# silenced due to bug in anemoi-inference for multi-step interpolators, can be removed when fixed
-verbosity: 0
+verbosity: 1
 allow_nans: true
 output_frequency: "1h"

--- a/resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml
+++ b/resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml
@@ -1,4 +1,4 @@
-runner: time_interpolator
+runner: temporal_downscaler
 
 input:
   cutout:
@@ -6,8 +6,8 @@ input:
         grib:
           path: forecaster/20*
           pre_processors:
-            - extract_mask: "source0/trimedge_mask"
             - forward_transform_filter:
+                # does not have an effect if the temporal downscaler does not use tp as prognostic variable
                 rescale:
                   scale: 0.001 # convert from kg m-2 to m
                   offset: 0
@@ -55,9 +55,7 @@ constant_forcings:
   test:
     use_original_paths: true
 
-patch_metadata:
-  dataset:
-    constant_fields: [z, lsm]
+patch_metadata: resources/sgm-temporal-downscaler-ich1-oper-patch.yaml
 
 post_processors:
   - accumulate_from_start_of_forecast: # accumulate tp from start of forecast
@@ -76,13 +74,12 @@ output:
         encoding:
           typeOfGeneratingProcess: 2
         templates:
-            samples: resources/templates_index_cosmo.yaml
+            samples: resources/templates_index_icon.yaml
         post_processors:
           - extract_mask: # removes global points
               mask: "lam_0/cutout_mask"
               as_slice: true
-          - assign_mask:  # fill boundary "trimmed" points with nan
-              mask: "source0/trimedge_mask"
+          # here, the trimedge mask can be specified when available
 
     - grib:
         path: grib/ifs-{dateTime}_{step:03}.grib
@@ -128,6 +125,7 @@ output:
                 "^w_(\\d+)$": {"param": 135, "shortName": "w"}
                 "^z_(\\d+)$": {"param": 129, "shortName": "z"}
 
-verbosity: 1
+# silenced due to bug in anemoi-inference for multi-step temporal downscalers, can be removed when fixed
+verbosity: 0
 allow_nans: true
 output_frequency: "1h"

--- a/resources/inference/metadata/sgm-temporal-downscaler-ich1-oper-patch.yaml
+++ b/resources/inference/metadata/sgm-temporal-downscaler-ich1-oper-patch.yaml
@@ -18,7 +18,7 @@ config:
 dataset:
   data:
     constant_fields: [z, lsm]
-    # variables_metadata is necessary due to missing variables_metadata section in interpolator patch_metdata
+    # variables_metadata is necessary due to missing variables_metadata section in temporal downscaler patch_metdata
     # else mapping with grib templates fails
     variables_metadata:
       10u:

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -140,20 +140,24 @@ class ForecasterConfig(RunConfig):
     )
 
 
-class InterpolatorConfig(RunConfig):
+class TemporalDownscalerConfig(RunConfig):
     """Single training run stored in MLflow."""
 
     config: Dict[str, Any] | str = Field(
         default_factory=lambda _: str(
-            PROJECT_ROOT / "resources" / "inference" / "configs" / "interpolator.yaml"
+            PROJECT_ROOT
+            / "resources"
+            / "inference"
+            / "configs"
+            / "temporal_downscaler.yaml"
         ),
-        description="Configuration for the interpolator run. Can be a dictionary of parameters or a path to a configuration file. "
-        "By default, it will point to resources/inference/configs/interpolator.yaml in the evalml repository.",
+        description="Configuration for the temporal downscaler run. Can be a dictionary of parameters or a path to a configuration file. "
+        "By default, it will point to resources/inference/configs/temporal_downscaler.yaml in the evalml repository.",
     )
 
     forecaster: ForecasterConfig | None = Field(
         None,
-        description="Configuration for the forecaster run that this interpolator is based on.",
+        description="Configuration for the forecaster run that this temporal downscaler is based on.",
     )
 
 
@@ -207,8 +211,8 @@ class ForecasterItem(BaseModel):
     forecaster: ForecasterConfig
 
 
-class InterpolatorItem(BaseModel):
-    interpolator: InterpolatorConfig
+class TemporalDownscalerItem(BaseModel):
+    temporal_downscaler: TemporalDownscalerConfig
 
 
 class BaselineItem(BaseModel):
@@ -472,9 +476,9 @@ class ConfigModel(BaseModel):
         description="Optional label for the experiment that will be used in the experiment directory name. Defaults to the config file name if not provided.",
     )
     dates: Dates | ExplicitDates
-    runs: List[ForecasterItem | InterpolatorItem | BaselineItem] = Field(
+    runs: List[ForecasterItem | TemporalDownscalerItem | BaselineItem] = Field(
         ...,
-        description="List of experiment participants, including forecaster/interpolator ML runs and baselines.",
+        description="List of experiment participants, including forecaster/temporal downscaler ML runs and baselines.",
     )
     truth: TruthConfig | None
     experiment: ExperimentConfig = Field(

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -71,7 +71,7 @@ class RunConfig(BaseModel):
     )
     checkpoint: str = Field(
         ...,
-        description="The mlflow run ID, as a 32-character hexadecimal string.",
+        description="The model checkpoint to use. Can be an MLflow run URL, a Hugging Face `.ckpt` URL, or a local checkpoint path.",
     )
     label: str | None = Field(
         None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ def example_forecasters_config():
 
 
 @pytest.fixture
-def example_interpolators_config():
-    configfile = PROJECT_ROOT / "config/interpolators-ich1.yaml"
+def example_temporal_downscalers_config():
+    configfile = PROJECT_ROOT / "config/temporal-downscalers-ich1.yaml"
     with open(configfile, "r") as f:
         config = yaml.safe_load(f)
     return config

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,13 +15,13 @@ def test_example_forecasters_config(example_forecasters_config):
         _ = ConfigModel.model_validate(example_forecasters_config)
 
 
-def test_example_interpolators_config(example_interpolators_config):
+def test_example_temporal_downscalers_config(example_temporal_downscalers_config):
     """Test that the example config loads correctly."""
 
     # this shoudd not raise an error
-    _ = ConfigModel.model_validate(example_interpolators_config)
+    _ = ConfigModel.model_validate(example_temporal_downscalers_config)
 
     # this should raise an error
-    del example_interpolators_config["runs"]
+    del example_temporal_downscalers_config["runs"]
     with pytest.raises(ValueError, match="Field required"):
-        _ = ConfigModel.model_validate(example_interpolators_config)
+        _ = ConfigModel.model_validate(example_temporal_downscalers_config)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -162,7 +162,7 @@ def register_run(model_type, run_config, as_candidate=True):
     mid = model_id(run_cfg["checkpoint"])
 
     out = {}
-    if model_type == "interpolator":
+    if model_type == "temporal_downscaler":
         forecaster = run_cfg.get("forecaster")
         if forecaster is None:
             run_cfg["forecaster"] = None
@@ -182,7 +182,7 @@ def register_run(model_type, run_config, as_candidate=True):
     # Compute env_id (determines which venv/squashfs to use)
     e_hash = env_entry_hash(run_cfg, model_type)
     env_id_base = f"{model_type}-{mid}-{e_hash}"
-    if model_type == "interpolator":
+    if model_type == "temporal_downscaler":
         env_id = f"{env_id_base}-on-{env_dep_suffix}"
     else:
         env_id = env_id_base
@@ -292,11 +292,11 @@ def env_entry_hash(run_config: dict, model_type: str) -> str:
     - checkpoint (different model)
     - extra_requirements (different dependencies)
     - disable_local_eccodes_definitions (different ECCODES setup)
-    - For interpolators: the forecaster's env_id (different upstream model)
+    - For temporal downscalers: the forecaster's env_id (different upstream model)
     """
     cfg = {k: v for k, v in run_config.items() if k in ENV_HASH_FIELDS}
     configs_to_hash = [cfg]
-    if model_type == "interpolator" and run_config.get("forecaster"):
+    if model_type == "temporal_downscaler" and run_config.get("forecaster"):
         # environment depends on which forecaster model (not which run config)
         configs_to_hash.append(run_config["forecaster"].get("env_id"))
     return generate_json_hash(configs_to_hash)
@@ -308,12 +308,12 @@ def run_specific_hash(run_config: dict, model_type: str) -> str:
     Changes to these fields create a new run_id (new outputs) but reuse the environment:
     - steps (lead times)
     - config YAML file contents (inference parameters)
-    - For interpolators: the forecaster's run_id (which run's outputs to read)
+    - For temporal downscalers: the forecaster's run_id (which run's outputs to read)
     """
     configs_to_hash = [{"steps": run_config["steps"]}]
     with open(run_config["config"], "r") as f:
         configs_to_hash.append(yaml.safe_load(f))
-    if model_type == "interpolator" and run_config.get("forecaster"):
+    if model_type == "temporal_downscaler" and run_config.get("forecaster"):
         # run output depends on which forecaster RUN was used (not just the env)
         configs_to_hash.append(run_config["forecaster"].get("run_id"))
     return generate_json_hash(configs_to_hash)

--- a/workflow/rules/inference.smk
+++ b/workflow/rules/inference.smk
@@ -206,8 +206,8 @@ def _get_forecaster_run_id(run_id):
     return RUN_CONFIGS[run_id]["forecaster"]["run_id"]
 
 
-# Prepare interpolator for a specific run ID
-rule inference_prepare_interpolator:
+# Prepare temporal downscaler for a specific run ID
+rule inference_prepare_temporal_downscaler:
     input:
         checkpoint=lambda wc: OUT_ROOT
         / f"data/runs/{RUN_CONFIGS[wc.run_id]['env_id']}/inference-last.ckpt",
@@ -226,10 +226,11 @@ rule inference_prepare_interpolator:
         grib_out_dir=directory(OUT_ROOT / "data/runs/{run_id}/{init_time}/grib"),
         forecaster=directory(OUT_ROOT / "data/runs/{run_id}/{init_time}/forecaster"),
         okfile=touch(
-            OUT_ROOT / "logs/inference_prepare_interpolator/{run_id}-{init_time}.ok"
+            OUT_ROOT
+            / "logs/inference_prepare_temporal_downscaler/{run_id}-{init_time}.ok"
         ),
     log:
-        OUT_ROOT / "logs/inference_prepare_interpolator/{run_id}-{init_time}.log",
+        OUT_ROOT / "logs/inference_prepare_temporal_downscaler/{run_id}-{init_time}.log",
     localrule: True
     params:
         lead_time=lambda wc: get_leadtime(wc),
@@ -253,9 +254,9 @@ def _inference_routing_fn(wc):
 
     if run_config["model_type"] == "forecaster":
         input_path = f"logs/inference_prepare_forecaster/{wc.run_id}-{wc.init_time}.ok"
-    elif run_config["model_type"] == "interpolator":
+    elif run_config["model_type"] == "temporal_downscaler":
         input_path = (
-            f"logs/inference_prepare_interpolator/{wc.run_id}-{wc.init_time}.ok"
+            f"logs/inference_prepare_temporal_downscaler/{wc.run_id}-{wc.init_time}.ok"
         )
     else:
         raise ValueError(f"Unsupported model type: {run_config['model_type']}")

--- a/workflow/scripts/inference_prepare.py
+++ b/workflow/scripts/inference_prepare.py
@@ -56,8 +56,8 @@ def prepare_workdir(workdir: Path, resources_root: Path):
     )
 
 
-def prepare_interpolator(smk):
-    """Prepare the interpolator for the inference run.
+def prepare_temporal_downscaler(smk):
+    """Prepare the temporal downscaler for the inference run.
 
     Required steps:
     - prepare working directory
@@ -99,7 +99,7 @@ def prepare_interpolator(smk):
         config_content = f.read()
     LOG.info("Config: \n%s", config_content)
 
-    LOG.info("Interpolator preparation complete.")
+    LOG.info("Temporal downscaler preparation complete.")
 
 
 def prepare_forecaster(smk):
@@ -168,8 +168,8 @@ def main(smk):
     """Main function to run the Snakemake workflow."""
     if smk.rule == "inference_prepare_forecaster":
         prepare_forecaster(smk)
-    elif smk.rule == "inference_prepare_interpolator":
-        prepare_interpolator(smk)
+    elif smk.rule == "inference_prepare_temporal_downscaler":
+        prepare_temporal_downscaler(smk)
     else:
         raise ValueError(f"Unknown rule: {smk.rule}")
 

--- a/workflow/scripts/plot_forecast_frame.py
+++ b/workflow/scripts/plot_forecast_frame.py
@@ -147,7 +147,10 @@ def main():
     if param == "TOT_PREC":
         prev_lt = lead_time - accu
         if prev_lt > 0:
-            prev_grib_file = grib_dir / f"{init_time}_{prev_lt:03d}.grib"
+            prev_grib_files = list(grib_dir.glob(f"2*_{prev_lt}.grib"))
+            if not prev_grib_files:
+                prev_grib_files = list(grib_dir.glob(f"2*_{prev_lt:03d}.grib"))
+            prev_grib_file = Path(prev_grib_files[0])
             LOG.info(
                 "De-accumulating TOT_PREC: loading previous grib file %s",
                 prev_grib_file,

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -305,7 +305,7 @@
       "description": "Single training run stored in MLflow.",
       "properties": {
         "checkpoint": {
-          "description": "The mlflow run ID, as a 32-character hexadecimal string.",
+          "description": "The model checkpoint to use. Can be an MLflow run URL, a Hugging Face `.ckpt` URL, or a local checkpoint path.",
           "title": "Checkpoint",
           "type": "string"
         },
@@ -657,7 +657,7 @@
       "description": "Single training run stored in MLflow.",
       "properties": {
         "checkpoint": {
-          "description": "The mlflow run ID, as a 32-character hexadecimal string.",
+          "description": "The model checkpoint to use. Can be an MLflow run URL, a Hugging Face `.ckpt` URL, or a local checkpoint path.",
           "title": "Checkpoint",
           "type": "string"
         },

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -486,104 +486,6 @@
       "title": "InferenceResources",
       "type": "object"
     },
-    "InterpolatorConfig": {
-      "additionalProperties": false,
-      "description": "Single training run stored in MLflow.",
-      "properties": {
-        "checkpoint": {
-          "description": "The mlflow run ID, as a 32-character hexadecimal string.",
-          "title": "Checkpoint",
-          "type": "string"
-        },
-        "label": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The label for the run that will be used in experiment results such as reports and figures.",
-          "title": "Label"
-        },
-        "steps": {
-          "description": "Forecast lead times in hours, formatted as 'start/end/step'. The range includes the start lead time and continues with the given step until reaching or exceeding the end lead time. Example: '0/120/6' for lead times every 6 hours up to 120 h, or '0/33/6' up to 30 h.",
-          "title": "Steps",
-          "type": "string"
-        },
-        "extra_requirements": {
-          "description": "List of extra dependencies to install for this model. These will be added to the requirements.txt file in the run directory.",
-          "items": {
-            "type": "string"
-          },
-          "title": "Extra Requirements",
-          "type": "array"
-        },
-        "inference_resources": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InferenceResources"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Resource requirements for inference jobs (optional; defaults handled externally)."
-        },
-        "disable_local_eccodes_definitions": {
-          "default": false,
-          "description": "If true, the ECCODES_DEFINITION_PATH environment variable will not be set to the COSMO local definitions.",
-          "title": "Disable Local Eccodes Definitions",
-          "type": "boolean"
-        },
-        "config": {
-          "anyOf": [
-            {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "Configuration for the interpolator run. Can be a dictionary of parameters or a path to a configuration file. By default, it will point to resources/inference/configs/interpolator.yaml in the evalml repository.",
-          "title": "Config"
-        },
-        "forecaster": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ForecasterConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Configuration for the forecaster run that this interpolator is based on."
-        }
-      },
-      "required": [
-        "checkpoint",
-        "steps"
-      ],
-      "title": "InterpolatorConfig",
-      "type": "object"
-    },
-    "InterpolatorItem": {
-      "properties": {
-        "interpolator": {
-          "$ref": "#/$defs/InterpolatorConfig"
-        }
-      },
-      "required": [
-        "interpolator"
-      ],
-      "title": "InterpolatorItem",
-      "type": "object"
-    },
     "Locations": {
       "description": "Locations of data and services used in the workflow.",
       "properties": {
@@ -750,6 +652,104 @@
       "title": "Stratification",
       "type": "object"
     },
+    "TemporalDownscalerConfig": {
+      "additionalProperties": false,
+      "description": "Single training run stored in MLflow.",
+      "properties": {
+        "checkpoint": {
+          "description": "The mlflow run ID, as a 32-character hexadecimal string.",
+          "title": "Checkpoint",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The label for the run that will be used in experiment results such as reports and figures.",
+          "title": "Label"
+        },
+        "steps": {
+          "description": "Forecast lead times in hours, formatted as 'start/end/step'. The range includes the start lead time and continues with the given step until reaching or exceeding the end lead time. Example: '0/120/6' for lead times every 6 hours up to 120 h, or '0/33/6' up to 30 h.",
+          "title": "Steps",
+          "type": "string"
+        },
+        "extra_requirements": {
+          "description": "List of extra dependencies to install for this model. These will be added to the requirements.txt file in the run directory.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Extra Requirements",
+          "type": "array"
+        },
+        "inference_resources": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InferenceResources"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Resource requirements for inference jobs (optional; defaults handled externally)."
+        },
+        "disable_local_eccodes_definitions": {
+          "default": false,
+          "description": "If true, the ECCODES_DEFINITION_PATH environment variable will not be set to the COSMO local definitions.",
+          "title": "Disable Local Eccodes Definitions",
+          "type": "boolean"
+        },
+        "config": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Configuration for the temporal downscaler run. Can be a dictionary of parameters or a path to a configuration file. By default, it will point to resources/inference/configs/temporal_downscaler.yaml in the evalml repository.",
+          "title": "Config"
+        },
+        "forecaster": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ForecasterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Configuration for the forecaster run that this temporal downscaler is based on."
+        }
+      },
+      "required": [
+        "checkpoint",
+        "steps"
+      ],
+      "title": "TemporalDownscalerConfig",
+      "type": "object"
+    },
+    "TemporalDownscalerItem": {
+      "properties": {
+        "temporal_downscaler": {
+          "$ref": "#/$defs/TemporalDownscalerConfig"
+        }
+      },
+      "required": [
+        "temporal_downscaler"
+      ],
+      "title": "TemporalDownscalerItem",
+      "type": "object"
+    },
     "TruthConfig": {
       "description": "Configuration for the truth data used in the verification.",
       "properties": {
@@ -807,14 +807,14 @@
       "title": "Dates"
     },
     "runs": {
-      "description": "List of experiment participants, including forecaster/interpolator ML runs and baselines.",
+      "description": "List of experiment participants, including forecaster/temporal downscaler ML runs and baselines.",
       "items": {
         "anyOf": [
           {
             "$ref": "#/$defs/ForecasterItem"
           },
           {
-            "$ref": "#/$defs/InterpolatorItem"
+            "$ref": "#/$defs/TemporalDownscalerItem"
           },
           {
             "$ref": "#/$defs/BaselineItem"


### PR DESCRIPTION
In anemoi, the task formerly called "interpolator" has been officially renamed to "temporal downscaler" (see [anemoi training docs](https://anemoi.readthedocs.io/projects/training/en/latest/modules/train.html#available-tasks)). evalml uses the anemoi model type concept throughout its config schema, workflow rules, Python code, and config files. This rename keeps evalml aligned with upstream anemoi terminology. 