### PR TITLE
Fix dashboard/plots truncating lead times at 6h (from INCA)

### DIFF
--- a/workflow/scripts/verification_aggregation.py
+++ b/workflow/scripts/verification_aggregation.py
@@ -43,7 +43,7 @@ def aggregate_results(ds: xr.Dataset) -> xr.Dataset:
     ds = ds.assign_coords(
         season=lambda ds: ds["forecast_reference_time"].dt.season,
         init_hour=lambda ds: ds["forecast_reference_time"].dt.hour,
-    ).drop_vars(["time"], errors="ignore")
+    ).drop_vars(["time", "valid_time"], errors="ignore")
 
     # Counter used to track the number of forecast_reference_time samples per stratum so that
     # aggregated results can be correctly re-aggregated later (weighted mean).


### PR DESCRIPTION
After PR #162, the verification dashboard and metric plots stopped showing data beyond lead time 6h (INCA's maximum) even for models with up to 120h range. Scorecards were unaffected because they read individual verif files directly.