### PR TITLE
Fix showcases

### DIFF
--- a/config/forecasters-ich1-oper-fixed.yaml
+++ b/config/forecasters-ich1-oper-fixed.yaml
@@ -85,4 +85,3 @@ profile:
     runtime: "1h"
     gpus: 0
   jobs: 50
-

--- a/config/forecasters-ich1-oper-fixed.yaml
+++ b/config/forecasters-ich1-oper-fixed.yaml
@@ -85,5 +85,4 @@ profile:
     runtime: "1h"
     gpus: 0
   jobs: 50
-  batch_rules:
-    plot_forecast_frame: 8
+

--- a/config/forecasters-ich1-oper.yaml
+++ b/config/forecasters-ich1-oper.yaml
@@ -82,4 +82,3 @@ profile:
     runtime: "1h"
     gpus: 0
   jobs: 50
-

--- a/config/forecasters-ich1-oper.yaml
+++ b/config/forecasters-ich1-oper.yaml
@@ -82,5 +82,4 @@ profile:
     runtime: "1h"
     gpus: 0
   jobs: 50
-  batch_rules:
-    plot_forecast_frame: 8
+

--- a/config/forecasters-ich1.yaml
+++ b/config/forecasters-ich1.yaml
@@ -94,5 +94,4 @@ profile:
     runtime: "1h"
     gpus: 0
   jobs: 50
-  batch_rules:
-    plot_forecast_frame: 8
+

--- a/config/forecasters-ich1.yaml
+++ b/config/forecasters-ich1.yaml
@@ -94,4 +94,3 @@ profile:
     runtime: "1h"
     gpus: 0
   jobs: 50
-

--- a/config/interpolators-ich1.yaml
+++ b/config/interpolators-ich1.yaml
@@ -116,11 +116,10 @@ showcase:
   animations:
     enabled: true
     domains:
+      - globe
       - europe
+      - icon-ch1
       - switzerland
-      - name: alpine_arc
-        extent: [3.0, 17.0, 43.5, 48.5]
-        projection: orthographic
 
 locations:
   output_root: output/

--- a/config/interpolators-ich1.yaml
+++ b/config/interpolators-ich1.yaml
@@ -118,7 +118,8 @@ showcase:
     domains:
       - globe
       - europe
-      - icon-ch1
+      - alps
+      - icon-ch
       - switzerland
 
 locations:

--- a/config/interpolators-ich1.yaml
+++ b/config/interpolators-ich1.yaml
@@ -116,9 +116,9 @@ showcase:
   animations:
     enabled: true
     domains:
-      - globe
+      # - globe
       - europe
-      - alps
+      # - alps
       - icon-ch
       - switzerland
 

--- a/config/interpolators-ich1.yaml
+++ b/config/interpolators-ich1.yaml
@@ -136,5 +136,3 @@ profile:
     runtime: "1h"
     gpus: 0
   jobs: 50
-  batch_rules:
-    plot_forecast_frame: 8

--- a/src/plotting/__init__.py
+++ b/src/plotting/__init__.py
@@ -47,7 +47,7 @@ DOMAINS = {
         "projection": _PROJECTIONS["orthographic"],
     },
     "alps": {
-        "extent": [4.0, 16.5, 43.5, 48.5],
+        "extent": [4.5, 16.0, 43.5, 48.5],
         "projection": _PROJECTIONS["orthographic"],
     },
     "radar": {

--- a/src/plotting/__init__.py
+++ b/src/plotting/__init__.py
@@ -42,8 +42,20 @@ DOMAINS = {
         "extent": [-2.6, 19.5, 40.2, 52.3],
         "projection": _PROJECTIONS["orthographic"],
     },
-    "switzerland": {
+    "icon-ch": {
         "extent": [0, 17.5, 40.5, 53.0],
+        "projection": _PROJECTIONS["orthographic"],
+    },
+    "alps": {
+        "extent": [4.0, 16.5, 43.5, 48.5],
+        "projection": _PROJECTIONS["orthographic"],
+    },
+    "radar": {
+        "extent": [3.2, 12.5, 43.6, 49.4],
+        "projection": _PROJECTIONS["orthographic"],
+    },
+    "switzerland": {
+        "extent": [5.6, 10.8, 45.0, 48.6],
         "projection": _PROJECTIONS["orthographic"],
     },
 }

--- a/src/plotting/__init__.py
+++ b/src/plotting/__init__.py
@@ -227,11 +227,12 @@ class StatePlotter:
             )  # avoid interpolation being performed by earthkit-plots resulting in an error
             return style, plot_kwargs
 
-        # Continuous mode: remove None entries to avoid matplotlib errors
-        if plot_kwargs.get("colors", None) is None:
-            plot_kwargs.pop("colors", None)
-        if plot_kwargs.get("levels", None) is None:
-            plot_kwargs.pop("levels", None)
+        # Continuous mode: remove None entries so configure_style doesn't call
+        # style.with_overrides(colors=None, vmin=None, ...) and wipe the style's
+        # pre-configured values.
+        for key in ("colors", "levels", "cmap", "norm", "vmin", "vmax"):
+            if plot_kwargs.get(key) is None:
+                plot_kwargs.pop(key, None)
 
         return style, plot_kwargs
 

--- a/src/plotting/colormap_defaults.py
+++ b/src/plotting/colormap_defaults.py
@@ -12,17 +12,35 @@ def _fallback():
 
 
 _CMAP_DEFAULTS = {
-    "SP": {"cmap": plt.get_cmap("coolwarm", 11), "vmin": 800 * 100, "vmax": 1100 * 100},
-    "TD_2M": load_ncl_colormap("t2m_29lev.ct"),
-    "T_2M": load_ncl_colormap("t2m_29lev.ct") | {"units": "degC"},
-    "V_10M": load_ncl_colormap("modified_uv_17lev.ct") | {"units": "m/s"},
-    "U_10M": load_ncl_colormap("modified_uv_17lev.ct") | {"units": "m/s"},
-    "SP_10M": load_ncl_colormap("modified_uv_17lev.ct") | {"units": "m/s"},
-    # "10si": {"cmap": plt.get_cmap("GnBu", 11), "vmin": 0, "vmax": 25},
-    "T_850": {"cmap": plt.get_cmap("inferno", 11), "vmin": 220, "vmax": 310},
-    "FI_850": {"cmap": plt.get_cmap("coolwarm", 11), "vmin": 8000, "vmax": 17000},
-    "QV_925": load_ncl_colormap("RH_6lev.ct"),
+    "SP": {
+        "cmap": plt.get_cmap("coolwarm", 11),
+        "vmin": 800 * 100,
+        "vmax": 1100 * 100,
+        "extend": "both",
+    },
+    "TD_2M": load_ncl_colormap("t2m_29lev.ct") | {"extend": "both"},
+    "T_2M": load_ncl_colormap("t2m_29lev.ct") | {"units": "degC", "extend": "both"},
+    "V_10M": load_ncl_colormap("modified_uv_17lev.ct")
+    | {"units": "m/s", "extend": "both"},
+    "U_10M": load_ncl_colormap("modified_uv_17lev.ct")
+    | {"units": "m/s", "extend": "both"},
+    "SP_10M": load_ncl_colormap("modified_uv_17lev.ct")
+    | {"units": "m/s", "extend": "max"},
+    "T_850": {
+        "cmap": plt.get_cmap("inferno", 11),
+        "vmin": 220,
+        "vmax": 310,
+        "extend": "both",
+    },
+    "FI_850": {
+        "cmap": plt.get_cmap("coolwarm", 11),
+        "vmin": 8000,
+        "vmax": 17000,
+        "extend": "both",
+    },
+    "QV_925": load_ncl_colormap("RH_6lev.ct") | {"extend": "both"},
     "TOT_PREC_1H": {
+        "extend": "max",
         "colors": [
             "#ffffff",
             "#ebf6ff",
@@ -68,6 +86,7 @@ _CMAP_DEFAULTS = {
         ],
     },
     "TOT_PREC_6H": {
+        "extend": "max",
         "colors": [
             "#ffffff",
             "#d6e2ff",

--- a/src/plotting/colormap_loader.py
+++ b/src/plotting/colormap_loader.py
@@ -1,6 +1,6 @@
 import pathlib
 import numpy as np
-from matplotlib.colors import BoundaryNorm
+from matplotlib.colors import BoundaryNorm, ListedColormap
 
 # Base directory for colormap files
 BASE_DIR = (
@@ -50,6 +50,10 @@ def load_ncl_colormap(filename):
     if len(rgb) != n_levs + 1:
         raise ValueError(f"Expected {n_levs} RGB rows, got {len(rgb)}.")
 
-    norm = BoundaryNorm(boundaries=bounds, ncolors=len(rgb) - 1)
+    n_intervals = len(bounds) - 1
+    cmap = ListedColormap(rgb[1:-1], name=filename)
+    cmap.set_under(rgb[0])
+    cmap.set_over(rgb[-1])
+    norm = BoundaryNorm(boundaries=bounds, ncolors=n_intervals)
 
-    return {"cmap": rgb[1:-1], "norm": norm, "bounds": bounds}
+    return {"cmap": cmap, "norm": norm, "bounds": bounds}

--- a/tests/unit/test_colormaps.py
+++ b/tests/unit/test_colormaps.py
@@ -15,18 +15,20 @@ def test_load_valid_colormap(monkeypatch, tmp_path):
     monkeypatch.setattr(colormap_loader, "BASE_DIR", tmp_path)
 
     result = colormap_loader.load_ncl_colormap("test_colormap.ct")
-    # cmap is a list of RGB colors (earthkit-plots consumes it as `colors`)
-    assert isinstance(result["cmap"], np.ndarray)
+    assert isinstance(result["cmap"], ListedColormap)
     assert isinstance(result["norm"], BoundaryNorm)
 
     cmap = result["cmap"]
     norm = result["norm"]
     bounds = result["bounds"]
 
-    # cmap holds the n_levs-1 inner colors, under/over rows excluded
-    assert cmap.shape == (2, 3)
-    assert np.allclose(cmap[0], (40 / 255, 50 / 255, 60 / 255))
-    assert np.allclose(cmap[1], (70 / 255, 80 / 255, 90 / 255))
+    # cmap holds the n_levs-1 inner colors, under/over excluded
+    assert cmap.N == 2
+    assert np.allclose(cmap(0), (*[x / 255 for x in (40, 50, 60)], 1.0))
+    assert np.allclose(cmap(1), (*[x / 255 for x in (70, 80, 90)], 1.0))
+    # under/over are set separately
+    assert np.allclose(cmap.get_under(), (*[x / 255 for x in (10, 20, 30)], 1.0))
+    assert np.allclose(cmap.get_over(), (*[x / 255 for x in (100, 110, 120)], 1.0))
     # bounds
     assert np.allclose(norm.boundaries, [0, 1, 2])
     assert np.allclose(bounds, [0, 1, 2])
@@ -69,11 +71,6 @@ def test_cmap_defaults_smoke(field, var):
     norm = var.get("norm", None)
     vmin = var.get("vmin", None)
     vmax = var.get("vmax", None)
-
-    # NCL colormaps are stored as a list of RGB colors (earthkit-plots
-    # consumes them as `colors`); wrap into a ListedColormap to plot here.
-    if isinstance(cmap, np.ndarray):
-        cmap = ListedColormap(cmap)
 
     # make some synthetic data
     data = np.linspace(0, 1, 100).reshape(10, 10)

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -143,7 +143,8 @@ def get_leadtimes(wc):
 rule make_forecast_animation:
     input:
         lambda wc: expand(
-            rules.plot_forecast_frame.output,
+            OUT_ROOT
+            / "data/runs/{run_id}/{init_time}/frames/frame_{leadtime}_{param}_{region}.png",
             run_id=wc.run_id,
             init_time=wc.init_time,
             param=wc.param,

--- a/workflow/scripts/plot_forecast_frame.py
+++ b/workflow/scripts/plot_forecast_frame.py
@@ -7,6 +7,7 @@ import cartopy.crs as ccrs
 from earthkit.meteo.utils.convert import kelvin_to_celsius
 import earthkit.meteo.wind as ekm_wind
 import earthkit.plots as ekp
+from matplotlib.colors import Colormap
 import numpy as np
 
 from plotting import DOMAINS
@@ -27,19 +28,47 @@ def get_style(param, units_override=None, accu=1):
     lookup = f"{param}_{accu}H" if param == "TOT_PREC" else param
     cfg = CMAP_DEFAULTS[lookup]
     units = units_override if units_override is not None else cfg.get("units", "")
+
+    bounds = cfg.get("bounds", cfg.get("levels", None))
+    prebuilt_cmap = cfg.get("cmap", None)
+
+    # When the config provides a pre-built matplotlib Colormap (e.g. a
+    # ListedColormap), we must use the earthkit Style's vmin/vmax path, which
+    # handles isinstance(colors, Colormap) correctly.  The levels path calls
+    # cmap_and_norm → len(Colormap) → TypeError.
+    #
+    # earthkit's configure_style intercepts _STYLE_KWARGS (cmap/colors/levels/vmin/vmax)
+    # from tricontourf kwargs before matplotlib sees them.  To work around this:
+    #  - embed the Colormap directly in the Style via colors=
+    #  - inject bounds as 'levels' into style._kwargs so they survive to matplotlib
+    #  - pass only norm= as a kwarg (not in _STYLE_KWARGS, so not intercepted)
+    extend = cfg.get("extend", "both")
+
+    if isinstance(prebuilt_cmap, Colormap) and bounds is not None:
+        style = ekp.styles.Style(
+            colors=prebuilt_cmap,
+            vmin=bounds[0],
+            vmax=bounds[-1],
+            extend=extend,
+            units=units,
+        )
+        style._kwargs["levels"] = list(bounds)
+        return {
+            "style": style,
+            "norm": cfg.get("norm", None),
+        }
+
     return {
         "style": ekp.styles.Style(
-            levels=cfg.get("bounds", cfg.get("levels", None)),
-            extend="both",
+            levels=bounds,
+            extend=extend,
             units=units,
             colors=cfg.get("colors", None),
         ),
         "norm": cfg.get("norm", None),
-        "cmap": cfg.get("cmap", None),
-        "levels": cfg.get("levels", None),
+        "cmap": prebuilt_cmap,
         "vmin": cfg.get("vmin", None),
         "vmax": cfg.get("vmax", None),
-        "colors": cfg.get("colors", None),
     }
 
 


### PR DESCRIPTION
This PR fixes a few recent issues related to the showcase command.

- #154 changed `plot_forecast_frame` to output frames for all regions in a single job (to reduce data I/O). However, `make_forecast_animation` was not updated accordingly: its input lambda expanded `rules.plot_forecast_frame.output`, which already has {region} resolved for all regions, causing the `region=wc.region` argument to be silently ignored. As a result, every animation job collected frames from all regions and passed them all to convert, producing incorrect GIFs.
  - fix: 9fdefc8

- #162 with eartkit-plots 1.0 something broke in drawing the colormap for precip. For the fix I relied heavily on Claude and will need to be double checked. In essence, for `TOT_PREC`, it seems that because the hex color list was passed as a raw kwarg, it was setting `no_style=True`, after which `configure_style` had already popped colors → matplotlib used viridis. Fixed by embedding colors in the `Style` object rather than passing them as kwargs; `get_style` now detects a pre-built `Colormap` and uses earthkit's vmin/vmax path (which handles `Colormap` objects), injecting `levels` directly into `style._kwargs` to bypass interception. 

   - also, `extend` moved into each preset in `colormap_defaults.py` (precipitation uses "max" since values are clipped to ≥ 0)
   - fix: da014ab

- consolidate region domains: 671248e

- SLURM jobs timing out because `plot_forecast_frame` tasks were being grouped into batches of 8 per SLURM job, but `--cores 4` limited the inner snakemake to run them sequentially. With 8 tasks running sequentially at ~9 minutes each, they'd exceed the 20-minute SLURM time limit. By removing the batching, each task now runs independently in its own job, allowing them to execute in parallel.
  - fix: f9ea85c