### PR TITLE
Source of truth in verification results

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 CONFIG_ROOT = Path("config").resolve()
 OUT_ROOT = Path(config["locations"]["output_root"])
+TRUTH_LABEL = config["truth"]["label"]
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
 HASH_LENGTH = 4
@@ -273,10 +274,14 @@ def resolve_baseline_id(label: str) -> str:
 def collect_experiment_participants():
     participants = {}
     for base in BASELINE_CONFIGS.keys():
-        participants[base] = OUT_ROOT / f"data/baselines/{base}/verif_aggregated.nc"
+        participants[base] = (
+            OUT_ROOT / f"data/baselines/{base}/verif_aggregated_{TRUTH_LABEL}.nc"
+        )
     for exp in RUN_CONFIGS.keys():
         if RUN_CONFIGS[exp].get("_is_candidate", False):
-            participants[exp] = OUT_ROOT / f"data/runs/{exp}/verif_aggregated.nc"
+            participants[exp] = (
+                OUT_ROOT / f"data/runs/{exp}/verif_aggregated_{TRUTH_LABEL}.nc"
+            )
     return participants
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -8,7 +8,6 @@ from urllib.parse import urlparse
 
 CONFIG_ROOT = Path("config").resolve()
 OUT_ROOT = Path(config["locations"]["output_root"])
-TRUTH_LABEL = config["truth"]["label"]
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
 HASH_LENGTH = 4
@@ -23,6 +22,7 @@ ENV_HASH_FIELDS = {
 RUN_HASH_EXCLUDE = {"label", "inference_resources", "_is_candidate", "model_type"}
 # Fields excluded from baseline hashing (display metadata only).
 BASELINE_HASH_EXCLUDE = {"label"}
+TRUTH_HASH_EXCLUDE = {"label"}
 
 
 # ============================================================================
@@ -275,12 +275,12 @@ def collect_experiment_participants():
     participants = {}
     for base in BASELINE_CONFIGS.keys():
         participants[base] = (
-            OUT_ROOT / f"data/baselines/{base}/verif_aggregated_{TRUTH_LABEL}.nc"
+            OUT_ROOT / f"data/baselines/{base}/verif_aggregated_{TRUTH_HASH}.nc"
         )
     for exp in RUN_CONFIGS.keys():
         if RUN_CONFIGS[exp].get("_is_candidate", False):
             participants[exp] = (
-                OUT_ROOT / f"data/runs/{exp}/verif_aggregated_{TRUTH_LABEL}.nc"
+                OUT_ROOT / f"data/runs/{exp}/verif_aggregated_{TRUTH_HASH}.nc"
             )
     return participants
 
@@ -343,6 +343,12 @@ def master_hash() -> str:
     return generate_json_hash(configs_to_hash)
 
 
+def truth_hash(truth_config: dict) -> str:
+    """Generate a short hash of the configs for the truth data."""
+    cfg = {k: v for k, v in truth_config.items() if k not in TRUTH_HASH_EXCLUDE}
+    return generate_json_hash(cfg)
+
+
 REGIONS = parse_regions()
 SHOWCASE_REGIONS = parse_showcase_regions()
 SHOWCASE_PARAMS = config.get("showcase", {}).get("params", ["T_2M", "SP_10M"])
@@ -358,3 +364,4 @@ _scorecard = config.get("experiment", {}).get("scorecards") or {}
 SCORECARD_CONFIGS = (
     _scorecard.get("sections", {}) if _scorecard.get("enabled", True) else {}
 )
+TRUTH_HASH = truth_hash(config["truth"])

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -349,6 +349,7 @@ def truth_hash(truth_config: dict) -> str:
     return generate_json_hash(cfg)
 
 
+TRUTH_HASH = truth_hash(config["truth"])
 REGIONS = parse_regions()
 SHOWCASE_REGIONS = parse_showcase_regions()
 SHOWCASE_PARAMS = config.get("showcase", {}).get("params", ["T_2M", "SP_10M"])
@@ -364,4 +365,3 @@ _scorecard = config.get("experiment", {}).get("scorecards") or {}
 SCORECARD_CONFIGS = (
     _scorecard.get("sections", {}) if _scorecard.get("enabled", True) else {}
 )
-TRUTH_HASH = truth_hash(config["truth"])

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -273,16 +273,10 @@ def resolve_baseline_id(label: str) -> str:
 def collect_experiment_participants():
     participants = {}
     for base in BASELINE_CONFIGS.keys():
-        participants[base] = (
-            OUT_ROOT
-            / f"data/baselines/{base}/verif_aggregated_{config['truth']['label']}.nc"
-        )
+        participants[base] = OUT_ROOT / f"data/baselines/{base}/verif_aggregated.nc"
     for exp in RUN_CONFIGS.keys():
         if RUN_CONFIGS[exp].get("_is_candidate", False):
-            participants[exp] = (
-                OUT_ROOT
-                / f"data/runs/{exp}/verif_aggregated_{config['truth']['label']}.nc"
-            )
+            participants[exp] = OUT_ROOT / f"data/runs/{exp}/verif_aggregated.nc"
     return participants
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -273,10 +273,16 @@ def resolve_baseline_id(label: str) -> str:
 def collect_experiment_participants():
     participants = {}
     for base in BASELINE_CONFIGS.keys():
-        participants[base] = OUT_ROOT / f"data/baselines/{base}/verif_aggregated.nc"
+        participants[base] = (
+            OUT_ROOT
+            / f"data/baselines/{base}/verif_aggregated_{config['truth']['label']}.nc"
+        )
     for exp in RUN_CONFIGS.keys():
         if RUN_CONFIGS[exp].get("_is_candidate", False):
-            participants[exp] = OUT_ROOT / f"data/runs/{exp}/verif_aggregated.nc"
+            participants[exp] = (
+                OUT_ROOT
+                / f"data/runs/{exp}/verif_aggregated_{config['truth']['label']}.nc"
+            )
     return participants
 
 

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -18,7 +18,8 @@ rule verification_metrics_baseline:
         truth=config["truth"]["root"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT / "data/baselines/{baseline_id}/{init_time}/verif.nc",
+        OUT_ROOT
+        / f"data/baselines/{{baseline_id}}/{{init_time}}/verif_{TRUTH_LABEL}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_baseline/{baseline_id}-{init_time}.log",
     resources:
@@ -67,7 +68,7 @@ rule verification_metrics:
         truth=config["truth"]["root"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT / "data/runs/{run_id}/{init_time}/verif.nc",
+        OUT_ROOT / f"data/runs/{{run_id}}/{{init_time}}/verif_{TRUTH_LABEL}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics/{run_id}-{init_time}.log",
     resources:
@@ -120,7 +121,7 @@ rule verification_metrics_aggregation:
             allow_missing=True,
         ),
     output:
-        OUT_ROOT / "data/runs/{run_id}/verif_aggregated.nc",
+        OUT_ROOT / f"data/runs/{{run_id}}/verif_aggregated_{TRUTH_LABEL}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation/{run_id}.log",
     resources:
@@ -142,7 +143,7 @@ use rule verification_metrics_aggregation as verification_metrics_aggregation_ba
             allow_missing=True,
         ),
     output:
-        OUT_ROOT / "data/baselines/{baseline_id}/verif_aggregated.nc",
+        OUT_ROOT / f"data/baselines/{{baseline_id}}/verif_aggregated_{TRUTH_LABEL}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation_baseline/{baseline_id}.log",
 

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -18,8 +18,7 @@ rule verification_metrics_baseline:
         truth=config["truth"]["root"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT
-        / f"data/baselines/{{baseline_id}}/{{init_time}}/verif_{TRUTH_LABEL}.nc",
+        OUT_ROOT / f"data/baselines/{{baseline_id}}/{{init_time}}/verif_{TRUTH_HASH}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_baseline/{baseline_id}-{init_time}.log",
     resources:
@@ -68,7 +67,7 @@ rule verification_metrics:
         truth=config["truth"]["root"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT / f"data/runs/{{run_id}}/{{init_time}}/verif_{TRUTH_LABEL}.nc",
+        OUT_ROOT / f"data/runs/{{run_id}}/{{init_time}}/verif_{TRUTH_HASH}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics/{run_id}-{init_time}.log",
     resources:
@@ -121,7 +120,7 @@ rule verification_metrics_aggregation:
             allow_missing=True,
         ),
     output:
-        OUT_ROOT / f"data/runs/{{run_id}}/verif_aggregated_{TRUTH_LABEL}.nc",
+        OUT_ROOT / f"data/runs/{{run_id}}/verif_aggregated_{TRUTH_HASH}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation/{run_id}.log",
     resources:
@@ -143,7 +142,7 @@ use rule verification_metrics_aggregation as verification_metrics_aggregation_ba
             allow_missing=True,
         ),
     output:
-        OUT_ROOT / f"data/baselines/{{baseline_id}}/verif_aggregated_{TRUTH_LABEL}.nc",
+        OUT_ROOT / f"data/baselines/{{baseline_id}}/verif_aggregated_{TRUTH_HASH}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation_baseline/{baseline_id}.log",
 

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -16,10 +16,9 @@ rule verification_metrics_baseline:
         script="workflow/scripts/verification_metrics.py",
         forecast=lambda wc: BASELINE_CONFIGS[wc.baseline_id]["root"],
         truth=config["truth"]["root"],
-        truth_label=config["truth"]["label"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT / "data/baselines/{baseline_id}/{init_time}/verif_{truth_label}.nc",
+        OUT_ROOT / "data/baselines/{baseline_id}/{init_time}/verif.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_baseline/{baseline_id}-{init_time}.log",
     resources:
@@ -68,8 +67,7 @@ rule verification_metrics:
         truth=config["truth"]["root"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT
-        / f"data/runs/{{run_id}}/{{init_time}}/verif_{config['truth']['label']}.nc",
+        OUT_ROOT / "data/runs/{run_id}/{init_time}/verif.nc",
     log:
         OUT_ROOT / "logs/verification_metrics/{run_id}-{init_time}.log",
     resources:
@@ -122,8 +120,7 @@ rule verification_metrics_aggregation:
             allow_missing=True,
         ),
     output:
-        OUT_ROOT
-        / f"data/runs/{{run_id}}/verif_aggregated_{config['truth']['label']}.nc",
+        OUT_ROOT / "data/runs/{run_id}/verif_aggregated.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation/{run_id}.log",
     resources:
@@ -145,8 +142,7 @@ use rule verification_metrics_aggregation as verification_metrics_aggregation_ba
             allow_missing=True,
         ),
     output:
-        OUT_ROOT
-        / f"data/baselines/{{baseline_id}}/verif_aggregated_{config['truth']['label']}.nc",
+        OUT_ROOT / "data/baselines/{baseline_id}/verif_aggregated.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation_baseline/{baseline_id}.log",
 

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -16,9 +16,10 @@ rule verification_metrics_baseline:
         script="workflow/scripts/verification_metrics.py",
         forecast=lambda wc: BASELINE_CONFIGS[wc.baseline_id]["root"],
         truth=config["truth"]["root"],
+        truth_label=config["truth"]["label"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT / "data/baselines/{baseline_id}/{init_time}/verif.nc",
+        OUT_ROOT / "data/baselines/{baseline_id}/{init_time}/verif_{truth_label}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_baseline/{baseline_id}-{init_time}.log",
     resources:
@@ -67,7 +68,8 @@ rule verification_metrics:
         truth=config["truth"]["root"],
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
-        OUT_ROOT / "data/runs/{run_id}/{init_time}/verif.nc",
+        OUT_ROOT
+        / f"data/runs/{{run_id}}/{{init_time}}/verif_{config['truth']['label']}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics/{run_id}-{init_time}.log",
     resources:
@@ -120,7 +122,8 @@ rule verification_metrics_aggregation:
             allow_missing=True,
         ),
     output:
-        OUT_ROOT / "data/runs/{run_id}/verif_aggregated.nc",
+        OUT_ROOT
+        / f"data/runs/{{run_id}}/verif_aggregated_{config['truth']['label']}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation/{run_id}.log",
     resources:
@@ -142,7 +145,8 @@ use rule verification_metrics_aggregation as verification_metrics_aggregation_ba
             allow_missing=True,
         ),
     output:
-        OUT_ROOT / "data/baselines/{baseline_id}/verif_aggregated.nc",
+        OUT_ROOT
+        / f"data/baselines/{{baseline_id}}/verif_aggregated_{config['truth']['label']}.nc",
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation_baseline/{baseline_id}.log",
 

--- a/workflow/scripts/verification_metrics.py
+++ b/workflow/scripts/verification_metrics.py
@@ -85,8 +85,6 @@ def main(args: ScriptConfig):
     )
 
     # save results to NetCDF
-    results.attrs["truth_label"] = args.truth_label
-    results.attrs["truth_root"] = str(args.truth)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     results.earthkit.to_netcdf(args.output)
     LOG.info("Saved verification results to %s", args.output)

--- a/workflow/scripts/verification_metrics.py
+++ b/workflow/scripts/verification_metrics.py
@@ -85,6 +85,8 @@ def main(args: ScriptConfig):
     )
 
     # save results to NetCDF
+    results.attrs["truth_label"] = args.truth_label
+    results.attrs["truth_root"] = str(args.truth)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     results.earthkit.to_netcdf(args.output)
     LOG.info("Saved verification results to %s", args.output)


### PR DESCRIPTION
Currently, we don't record the truth used to produce verification results. Therefore, if you recompute evaluation with a different truth (e.g. analysis / stations), the intermediate verification files (currently `verif.nc` and `verif_aggregated.nc`) will be overwritten. To avoid this, we propose to make intermediate verification results truth-specific. Also, this may open up the possibility to run evaluation experiments with multiple truth data sources in the future.

### Summary of changes
* introduce truth (label) in rules producing intermediate verification files
* record truth label and root in NetCDF metadata (convenience)