### PR TITLE
Expose SLURM account and GPUs from config

### DIFF
--- a/config/temporal-downscalers-ich1.yaml
+++ b/config/temporal-downscalers-ich1.yaml
@@ -129,5 +129,5 @@ profile:
     mem_mb_per_cpu: 1800
     runtime: "1h"
     gpus: 0
-    account: s83
+    slurm_account: s83
   jobs: 50

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -404,10 +404,20 @@ class DefaultResources(BaseModel):
     cpus_per_task: int = Field(..., ge=1, description="Number of CPUs per task.")
     mem_mb_per_cpu: int = Field(..., ge=1, description="Memory per CPU in MB.")
     runtime: str = Field(..., description="Maximum runtime, e.g. '1h'.")
+    slurm_account: str | None = Field(None, description="SLURM account to charge.")
+    gpus: int | None = Field(
+        None, ge=0, description="Default GPU count per job (0 for non-GPU jobs)."
+    )
 
-    def parsable(self) -> str:
+    model_config = {"extra": "forbid"}
+
+    def parsable(self) -> list[str]:
         """Convert the default resources to a string of key=value pairs."""
-        return [f"{key}={value}" for key, value in self.model_dump().items()]
+        return [
+            f"{key}={value}"
+            for key, value in self.model_dump().items()
+            if value is not None
+        ]
 
 
 class GlobalResources(BaseModel):

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -136,6 +136,7 @@
       "type": "object"
     },
     "DefaultResources": {
+      "additionalProperties": false,
       "description": "Default resource settings for job execution.",
       "properties": {
         "slurm_partition": {
@@ -159,6 +160,33 @@
           "description": "Maximum runtime, e.g. '1h'.",
           "title": "Runtime",
           "type": "string"
+        },
+        "slurm_account": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SLURM account to charge.",
+          "title": "Slurm Account"
+        },
+        "gpus": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Default GPU count per job (0 for non-GPU jobs).",
+          "title": "Gpus"
         }
       },
       "required": [


### PR DESCRIPTION
The slurm account is not passed on to snakemake options. 

### Summary of changes
* add slurm_account and gpus as optional fields in config schema
* rename to `slurm_account` in temporal downscaler config