### PR TITLE
Change default location for Prognoseregionen

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ experiment:
       - alpennordhang
       - innerealpentaeler
       - alpensuedseite
-    root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
+    root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
   # Optional: categorical thresholds used for binary skill scores, one entry per parameter.
   thresholds:
     TOT_PREC:

--- a/config/forecasters-ich1-oper-fixed.yaml
+++ b/config/forecasters-ich1-oper-fixed.yaml
@@ -54,7 +54,7 @@ experiment:
       - alpennordhang
       - innerealpentaeler
       - alpensuedseite
-    root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
+    root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
   thresholds:
     TOT_PREC:
       gt: [0.0, 1, 5]

--- a/config/forecasters-ich1-oper.yaml
+++ b/config/forecasters-ich1-oper.yaml
@@ -51,7 +51,7 @@ experiment:
       - alpennordhang
       - innerealpentaeler
       - alpensuedseite
-    root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
+    root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
   thresholds:
     TOT_PREC:
       gt: [0.0, 1, 5]

--- a/config/forecasters-ich1.yaml
+++ b/config/forecasters-ich1.yaml
@@ -63,7 +63,7 @@ experiment:
       - alpennordhang
       - innerealpentaeler
       - alpensuedseite
-    root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
+    root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
   thresholds:
     TOT_PREC:
       gt: [0.0, 1, 5]

--- a/config/temporal-downscalers-ich1.yaml
+++ b/config/temporal-downscalers-ich1.yaml
@@ -52,7 +52,7 @@ experiment:
       - alpennordseite
       - alpensuedseite
       - jura
-    root: /scratch/mch/bhendj/regions/Prognoseregionen_LV95_20220517
+    root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
   thresholds:
     TOT_PREC:
       gt: [0.0, 1, 5]


### PR DESCRIPTION
### Summary of Changes
* move the Prognoseregionen shapefiles from personal scratch to /store_new/mch/msopr/ml/regions/