### PR TITLE
Support MLflow model registry checkpoints

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -143,6 +143,10 @@ def model_id(checkpoint_uri: str) -> str:
     """Generate a model ID based on the checkpoint URI."""
     ckpt_type = _checkpoint_uri_type(checkpoint_uri)
     if ckpt_type == "mlflow":
+        fragment = checkpoint_uri.split("#")[-1]
+        if "/models/" in fragment:
+            parts = fragment.strip("/").split("/")
+            return f"{parts[1]}-v{parts[3]}"[:HASH_LENGTH]
         return checkpoint_uri.split("/")[-1][:HASH_LENGTH]
     elif ckpt_type == "huggingface":
         return checkpoint_uri.split("/")[-1].split(".")[0]

--- a/workflow/scripts/inference_get_checkpoint_mlflow.py
+++ b/workflow/scripts/inference_get_checkpoint_mlflow.py
@@ -17,12 +17,18 @@ def main(args):
     parsed_url = urlparse(run_uri)
     if parsed_url.netloc in KNOWN_MLFLOW_TRACKING_URI:
         uri, fragment = run_uri.split("#")
-        run_id = fragment.split("/")[-1]
         if parsed_url.netloc == "mlflow.ecmwf.int":
             TokenAuth(uri).login()
             client = AnemoiMlflowClient(uri, authentication=True)
         else:
             client = MlflowClient(tracking_uri=uri)
+        if "/models/" in fragment:
+            parts = fragment.strip("/").split("/")
+            model_name, version = parts[1], parts[3]
+            model_version = client.get_model_version(model_name, version)
+            run_id = model_version.run_id
+        else:
+            run_id = fragment.split("/")[-1]
         run = client.get_run(run_id)
         path = run.data.params.get("config.hardware.paths.checkpoints")
         path = path or run.data.params.get("config.system.output.checkpoints.root")


### PR DESCRIPTION
Support MLflow model registry URLs as checkpoint references, in addition to run-based URLs.

## Previously supported (run-based):
checkpoint: https://service.meteoswiss.ch/mlstore#/experiments/42/runs/abc123...

## Now also supported (model registry):
checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-1-forecaster/versions/4