### PR TITLE
Revert no-extras on resource config

### DIFF
--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -409,8 +409,6 @@ class DefaultResources(BaseModel):
         None, ge=0, description="Default GPU count per job (0 for non-GPU jobs)."
     )
 
-    model_config = {"extra": "forbid"}
-
     def parsable(self) -> list[str]:
         """Convert the default resources to a string of key=value pairs."""
         return [

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -136,7 +136,6 @@
       "type": "object"
     },
     "DefaultResources": {
-      "additionalProperties": false,
       "description": "Default resource settings for job execution.",
       "properties": {
         "slurm_partition": {


### PR DESCRIPTION
With #180 no-extras was introduced in the resource block of the config files. This prohibits the user from e.g. excluding nodes via `slurm_extra: "'--exclude <somenode>'"`. This change has been reverted in this PR.

### Summary of changes
* allow extra arguments to default resources