### PR TITLE
Add meteogram and centralise plot style

### DIFF
--- a/config/Varda-Single_paper.yaml
+++ b/config/Varda-Single_paper.yaml
@@ -97,6 +97,10 @@ experiment:
 
 publication:
   enabled: true
+  meteogram:
+    init_time: "202504010000"
+    station: "KLO"
+    params: [T_2M, TOT_PREC, SP_10M, DD_10M]
 
 locations:
   output_root: output/

--- a/config/aifs-single.yaml
+++ b/config/aifs-single.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=../workflow/tools/config.schema.json
+description: |
+  Evaluate skill of ECMWF AIFS-single.
+
+config_label: AIFS-single-1.1
+
+
+dates:
+  start: 2024-01-01T00:00
+  end: 2024-01-01T00:00
+  frequency: 24h
+
+runs:
+  - forecaster:
+      checkpoint: https://huggingface.co/ecmwf/aifs-single-1.1/resolve/main/aifs-single-mse-1.1.ckpt
+      label: AIFS-single-1.1
+      steps: 0/120/6
+      config: resources/inference/configs/aifs-single-forecaster.yaml
+      extra_requirements:
+        - torch-geometric==2.4.0
+        - anemoi-inference==0.6.3
+        - anemoi-models==0.5.0
+        - https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp312-cp312-linux_x86_64.whl
+      disable_local_eccodes_definitions: true
+      inference_resources:
+        slurm_partition: preemptible
+        gpus: 1
+truth:
+  label: KENDA-CH1
+  root: /store_new/mch/msopr/ml/datasets/mch-ich1-1km-2024-2025-1h-pl13-v1.0.zarr
+
+experiment:
+  params:
+    - T_2M
+    - TD_2M
+    - U_10M
+    - V_10M
+    - TOT_PREC
+  dashboard:
+    stratification:
+      # - region
+      # - init_hour
+      - season
+  stratification:
+    regions: []
+
+locations:
+  output_root: output/
+
+profile:
+  executor: slurm
+  global_resources:
+    gpus: 16
+  default_resources:
+    slurm_partition: "postproc"
+    cpus_per_task: 1
+    mem_mb_per_cpu: 1800
+    runtime: "1h"
+    gpus: 0
+  jobs: 50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+pythonpath = ["workflow/scripts", "src"]
 markers = [
     "longtest: mark tests that take a long time to run, e.g. integration tests",
 ]

--- a/resources/inference/configs/aifs-single-forecaster.yaml
+++ b/resources/inference/configs/aifs-single-forecaster.yaml
@@ -1,0 +1,20 @@
+input: test
+
+allow_nans: true
+
+patch_metadata:
+  config:
+    dataloader:
+      test:
+        dataset: /store_new/mch/msopr/ml/datasets/aifs-od-an-oper-0001-mars-n320-2016-2025-6h-v1-combined-land.zarr
+
+post_processors:
+  - accumulate_from_start_of_forecast:
+      accumulations:
+        - tp
+
+output:
+  grib:
+    path: grib/{date}{time:04}_{step:03}.grib
+
+write_initial_state: true

--- a/src/data_input/__init__.py
+++ b/src/data_input/__init__.py
@@ -481,9 +481,9 @@ def load_truth_data(
             params=params,
         )
         truth = truth.compute().chunk(
-            {"y": -1, "x": -1}
+            {"time": 1, "y": -1, "x": -1}
             if "y" in truth.dims and "x" in truth.dims
-            else {"values": -1}
+            else {"time": 1, "values": -1}
         )
     elif "jretrieve" in str(root):
         LOG.info("Loading ground truth from JRetrieve...")

--- a/src/data_input/__init__.py
+++ b/src/data_input/__init__.py
@@ -11,6 +11,20 @@ from pyproj import Transformer
 
 LOG = logging.getLogger(__name__)
 
+# IFS shortNames that differ from ICON parameter names.
+# Used when loading GRIB output from global models (e.g. AIFS-single) that write IFS names.
+_IFS_TO_ICON = {
+    "tp": "TOT_PREC",
+    "msl": "PMSL",
+    "10u": "U_10M",
+    "10v": "V_10M",
+    "2t": "T_2M",
+    "2d": "TD_2M",
+    "sp": "PS",
+    "lsm": "FR_LAND",
+}
+_ICON_TO_IFS = {v: k for k, v in _IFS_TO_ICON.items()}
+
 XARRAY_ENGINE_PROFILE = {
     "ensure_dims": ["z", "number", "step", "forecast_reference_time"],
     "add_valid_time_coord": True,
@@ -62,20 +76,14 @@ def load_analysis_data_from_zarr(
     This function loads analysis data from a Zarr dataset, processing it to make it more
     xarray-friendly. It renames variables, sets the time index, and pivots the dataset.
     """
-    PARAMS_MAP_COSMO2 = {
-        "T_2M": "2t",
-        "TD_2M": "2d",
-        "U_10M": "10u",
-        "V_10M": "10v",
-        "PS": "sp",
-        "PMSL": "msl",
-        "TOT_PREC": "tp",
-    }
-    tot_prec_string = "TOT_PREC_6H" if min(np.diff(steps)) == 6 else "TOT_PREC_1H"
-    PARAMS_MAP_COSMO1 = {
-        v: v.replace("TOT_PREC", tot_prec_string) for v in PARAMS_MAP_COSMO2.keys()
-    }
-    PARAMS_MAP = PARAMS_MAP_COSMO2 if "co2" in root.name else PARAMS_MAP_COSMO1
+    USE_IFS_NAMES = {"-co2-", "-ea-", "ifsnames"}
+    if any(tag in root.name for tag in USE_IFS_NAMES):
+        # Zarr stores IFS shortNames; map ICON param names to IFS for selection
+        zarr_names = {p: _ICON_TO_IFS.get(p, p) for p in params}
+    else:
+        # Zarr stores ICON param names; TOT_PREC has a time-resolution suffix
+        tot_prec_key = "TOT_PREC_6H" if min(np.diff(steps)) == 6 else "TOT_PREC_1H"
+        zarr_names = {p: p.replace("TOT_PREC", tot_prec_key) for p in params}
 
     ds = xr.open_zarr(root, consolidated=False)
 
@@ -86,10 +94,10 @@ def load_analysis_data_from_zarr(
     ds = ds.assign_coords({"variable": ds.attrs["variables"]})
 
     # select variables and valid time, squeeze ensemble dimension
-    ds = ds.sel(variable=[PARAMS_MAP[p] for p in params]).squeeze("ensemble", drop=True)
+    ds = ds.sel(variable=[zarr_names[p] for p in params]).squeeze("ensemble", drop=True)
 
-    # recover original 2D shape
-    if len(ds.attrs["field_shape"]) == 2:
+    # recover original 2D shape (not present for global Gaussian grids)
+    if "field_shape" in ds.attrs and len(ds.attrs["field_shape"]) == 2:
         ny, nx = ds.attrs["field_shape"]
         y_idx, x_idx = np.unravel_index(np.arange(ny * nx), shape=(ny, nx))
         ds = ds.assign_coords({"y": ("cell", y_idx), "x": ("cell", x_idx)})
@@ -99,11 +107,12 @@ def load_analysis_data_from_zarr(
     # set lat lon as coords (optional)
     if "latitudes" in ds and "longitudes" in ds:
         ds = ds.rename({"latitudes": "latitude", "longitudes": "longitude"})
-    ds = ds.set_coords(["latitude", "longitude"])
+    if "latitude" in ds and "longitude" in ds:
+        ds = ds.set_coords(["latitude", "longitude"])
     ds = (
         ds["data"]
         .to_dataset("variable")
-        .rename({v: k for k, v in PARAMS_MAP.items() if v in ds["variable"].values})
+        .rename({v: k for k, v in zarr_names.items() if v in ds["variable"].values})
     )
 
     # change precipitation units from m to kg m-2
@@ -316,7 +325,19 @@ def load_forecast_data_from_grib(
       (no file exists), so it is synthesised as zero to form the first
       accumulation window. `steps` carries that intent.
     """
-    ds = load_from_grib_file(files, {"parameter.variable": params})
+    # Extend param selection to include IFS aliases so that global-model GRIB files
+    # (which use IFS shortNames like "tp", "2t") are also matched.
+    params_extended = list(
+        {p for p in params} | {_ICON_TO_IFS[p] for p in params if p in _ICON_TO_IFS}
+    )
+    ds = load_from_grib_file(files, {"parameter.variable": params_extended})
+
+    # Rename any IFS shortNames back to ICON names
+    ifs_rename = {
+        ifs: icon for ifs, icon in _IFS_TO_ICON.items() if ifs in ds.data_vars
+    }
+    if ifs_rename:
+        ds = ds.rename(ifs_rename)
 
     if "TOT_PREC" in ds.data_vars:
         ds["TOT_PREC"] = _tot_prec_handling(ds["TOT_PREC"], requested_steps=steps)

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -377,12 +377,12 @@ class Stratification(BaseModel):
     """Stratification settings for the analysis."""
 
     regions: List[str] = Field(
-        ...,
-        description="List of region names for stratification.",
+        default_factory=list,
+        description="List of region names for stratification. Empty list means no spatial stratification.",
     )
-    root: str = Field(
-        ...,
-        description="Root directory where the region shapefiles are stored.",
+    root: Optional[str] = Field(
+        None,
+        description="Root directory where the region shapefiles are stored. Required when regions is non-empty.",
     )
 
 

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -326,12 +326,35 @@ class ShowcaseConfig(BaseModel):
     )
 
 
+class PublicationMeteogramConfig(BaseModel):
+    """Case selection for the publication meteogram figure."""
+
+    init_time: str = Field(
+        ...,
+        description="Initialisation time (YYYYMMDDHHMM) of the case to plot.",
+    )
+    station: str = Field(
+        ...,
+        description="PeakWeather station ID to plot (e.g. KLO, GVE, LUG).",
+    )
+    params: List[str] = Field(
+        default=["T_2M", "TOT_PREC", "SP_10M", "DD_10M"],
+        description="Display parameters (one panel each); SP_10M/DD_10M are derived.",
+    )
+
+    model_config = {"extra": "forbid"}
+
+
 class PublicationConfig(BaseModel):
     """Configuration for the publication workflow."""
 
     enabled: bool = Field(
         default=False,
         description="Whether to generate publication figures.",
+    )
+    meteogram: Optional[PublicationMeteogramConfig] = Field(
+        default=None,
+        description="Publication meteogram case selection (omit to skip it).",
     )
 
 

--- a/src/plotting/compat.py
+++ b/src/plotting/compat.py
@@ -23,7 +23,18 @@ PARAMS_MAP_INV = {v: k for k, v in PARAMS_MAP.items()}
 def load_state_from_grib(
     file: Path, paramlist: list[str] | None = None
 ) -> dict[str, np.ndarray | dict[str, np.ndarray] | gpd.GeoSeries]:
-    ds = load_from_grib_file(file, {"parameter.variable": paramlist})
+    # Also request IFS shortname aliases
+    paramlist_extended = list(
+        {p for p in (paramlist or [])}
+        | {PARAMS_MAP[p] for p in (paramlist or []) if p in PARAMS_MAP}
+    )
+    ds = load_from_grib_file(file, {"parameter.variable": paramlist_extended})
+    # Rename any IFS shortnames back to COSMO names
+    ifs_rename = {
+        ifs: cosmo for ifs, cosmo in PARAMS_MAP_INV.items() if ifs in ds.data_vars
+    }
+    if ifs_rename:
+        ds = ds.rename(ifs_rename)
     state = {}
     ref_param = next((p for p in (paramlist or []) if p in ds), None)
     if ref_param is None:
@@ -38,11 +49,16 @@ def load_state_from_grib(
     state["valid_time"] = datetime.fromtimestamp(ds["valid_time"].values.item() / 1e9)
     state["longitudes"] = ds["longitude"].values.flatten()
     state["latitudes"] = ds["latitude"].values.flatten()
-    # Add the limited-area model envelope polygon (convex hull) before global coords are added
-    lam_hull = MultiPoint(
-        list(zip(state["longitudes"].tolist(), state["latitudes"].tolist()))
-    ).convex_hull
-    state["lam_envelope"] = gpd.GeoSeries([lam_hull], crs="EPSG:4326")
+    # Add the limited-area model envelope polygon (convex hull) before global coords are added.
+    # Skip for global grids (lon range ~360°) — the hull would cover the whole globe.
+    lon_range = state["longitudes"].max() - state["longitudes"].min()
+    if lon_range > 350:
+        state["lam_envelope"] = gpd.GeoSeries([], crs="EPSG:4326")
+    else:
+        lam_hull = MultiPoint(
+            list(zip(state["longitudes"].tolist(), state["latitudes"].tolist()))
+        ).convex_hull
+        state["lam_envelope"] = gpd.GeoSeries([lam_hull], crs="EPSG:4326")
     state["fields"] = {}
     for param in paramlist or []:
         if param in ds:

--- a/src/verification/__init__.py
+++ b/src/verification/__init__.py
@@ -98,30 +98,52 @@ def _binary_confusion_matrix(
     dim: list[str],
 ) -> xr.DataArray:
     """
-    Compute counts of the confusion matrix (contingency table, e.g. hits, misses, ...)
+    Compute confusion matrix counts (tp, fp, fn, tn, total) for all thresholds at once.
 
-    Return an xarray.DataArray with the definition of the events in the dimension as given by
-    `labels` and the elements of the confusion matrix in the dimension `contingency`.
+    Thresholds sharing the same operator are broadcast as a single extra dimension so
+    the spatial reduction happens in one dask pass instead of one pass per threshold.
     """
-    threshold_dim = xr.DataArray(
-        data=[f"{key}_{str(val).replace('.', 'p')}" for key, val in thresholds],
-        dims="threshold",
+    from collections import defaultdict
+
+    op_groups: dict[str, list[float]] = defaultdict(list)
+    for op_txt, val in thresholds:
+        op_groups[op_txt].append(val)
+
+    # Points where both fcst and obs carry valid (non-masked) data
+    valid = fcst.notnull() & obs.notnull()
+    # Fill NaN so comparisons return False rather than NaN for masked points
+    fcst_filled = fcst.where(valid, 0)
+    obs_filled = obs.where(valid, 0)
+
+    contingency_dim = xr.DataArray(
+        ["tp_count", "fp_count", "fn_count", "tn_count", "total_count"],
+        dims="contingency",
     )
-    contingency_table = []
-    for op_txt, value in thresholds:
+
+    tables = []
+    for op_txt, values in op_groups.items():
         try:
             op_fn = getattr(op, op_txt)
         except AttributeError:
             raise AttributeError(f"operator {op_txt} is not available")
-        event_operator = scores.categorical.ThresholdEventOperator(
-            default_event_threshold=value,
-            default_op_fn=op_fn,
+
+        threshold_labels = [f"{op_txt}_{str(v).replace('.', 'p')}" for v in values]
+        # Broadcast comparison across all threshold values simultaneously
+        vals_da = xr.DataArray(
+            values, dims="threshold", coords={"threshold": threshold_labels}
         )
-        contingency_manager = event_operator.make_contingency_manager(fcst, obs)
-        contingency_table.append(
-            contingency_manager.transform(reduce_dims=dim).get_table()
-        )
-    return xr.concat(contingency_table, dim=threshold_dim)
+        fcst_ev = op_fn(fcst_filled, vals_da)  # (...spatial/time..., threshold) bool
+        obs_ev = op_fn(obs_filled, vals_da)
+
+        tp = (fcst_ev & obs_ev & valid).sum(dim)
+        fp = (fcst_ev & ~obs_ev & valid).sum(dim)
+        fn = (~fcst_ev & obs_ev & valid).sum(dim)
+        tn = (~fcst_ev & ~obs_ev & valid).sum(dim)
+        total = valid.sum(dim).broadcast_like(tp)
+
+        tables.append(xr.concat([tp, fp, fn, tn, total], dim=contingency_dim))
+
+    return xr.concat(tables, dim="threshold")
 
 
 def _compute_scores(
@@ -204,16 +226,6 @@ def _merge_metrics(ds: xr.Dataset, num_workers: int = 4) -> xr.Dataset:
     return out
 
 
-def _compute_masks(ds: xr.Dataset) -> xr.Dataset:
-    # extract first data_var from ds and only retain x and y dimensions
-    darr = ds[list(ds.data_vars)[0]].isel(
-        **{dim: 0 for dim in ds[list(ds.data_vars)[0]].dims if dim not in ["x", "y"]}
-    )
-    # compile list of masks to use with data arrays in ds
-    mask = xr.ones_like(darr, dtype=bool).expand_dims(region=["all"])
-    return mask
-
-
 def verify(
     fcst: xr.Dataset,
     obs: xr.Dataset,
@@ -274,10 +286,6 @@ def verify(
         else:
             dim = ["values"]
 
-    # rewrite the verification to use dask and xarray
-    # chunk the data to avoid memory issues
-    # compute the metrics in parallel
-    # return the results as a xarray Dataset
     fcst_aligned, obs_aligned = xr.align(fcst, obs, join="inner", copy=False)
     region_polygons = ShapefileSpatialAggregationMasks(shp=regions)
     masks = region_polygons.get_masks(
@@ -290,54 +298,43 @@ def verify(
         if param not in obs_aligned.data_vars:
             LOG.warning("Parameter %s not in obs, skipping", param)
             continue
-        score = []
-        fcst_statistics = []
-        obs_statistics = []
         thresholds = (
             threshold_dict.get(param, None)
             if isinstance(threshold_dict, dict)
             else None
         )
-        LOG.info(f"Thresholds for {param}: {thresholds}")
-        for region in masks.region.values:
-            LOG.info("Verifying parameter %s for region %s", param, region)
-            fcst_param = fcst_aligned[param].where(masks.sel(region=region))
-            obs_param = obs_aligned[param].where(masks.sel(region=region))
+        LOG.info(
+            "Verifying parameter %s for %d regions, thresholds: %s",
+            param,
+            len(masks.region),
+            thresholds,
+        )
 
-            # scores vs time (reduce spatially)
-            score.append(
-                _compute_scores(
-                    fcst_param,
-                    obs_param,
-                    prefix=param + ".",
-                    source=fcst_label,
-                    dim=dim,
-                    thresholds=thresholds,
-                ).expand_dims(region=[region])
-            )
+        # Apply all region masks at once via broadcast — adds "region" as leading dim
+        fcst_param = fcst_aligned[param].where(masks)
+        obs_param = obs_aligned[param].where(masks)
 
-            # statistics vs time (reduce spatially)
-            fcst_statistics.append(
-                _compute_statistics(
-                    fcst_param,
-                    prefix=param + ".",
-                    source=fcst_label,
-                    dim=dim,
-                ).expand_dims(region=[region])
-            )
-            obs_statistics.append(
-                _compute_statistics(
-                    obs_param,
-                    prefix=param + ".",
-                    source=obs_label,
-                    dim=dim,
-                ).expand_dims(region=[region])
-            )
-
-        score = xr.concat(score, dim="region")
-        fcst_statistics = xr.concat(fcst_statistics, dim="region")
-        obs_statistics = xr.concat(obs_statistics, dim="region")
-        param_statistics = xr.concat([fcst_statistics, obs_statistics], dim="source")
+        score = _compute_scores(
+            fcst_param,
+            obs_param,
+            prefix=param + ".",
+            source=fcst_label,
+            dim=dim,
+            thresholds=thresholds,
+        )
+        fcst_stats = _compute_statistics(
+            fcst_param,
+            prefix=param + ".",
+            source=fcst_label,
+            dim=dim,
+        )
+        obs_stats = _compute_statistics(
+            obs_param,
+            prefix=param + ".",
+            source=obs_label,
+            dim=dim,
+        )
+        param_statistics = xr.concat([fcst_stats, obs_stats], dim="source")
         # Compute eagerly per parameter to prevent dask graph bloat
         scores.append(_merge_metrics([score], num_workers=num_workers))
         statistics.append(_merge_metrics([param_statistics], num_workers=num_workers))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,3 +25,17 @@ def test_example_temporal_downscalers_config(example_temporal_downscalers_config
     del example_temporal_downscalers_config["runs"]
     with pytest.raises(ValueError, match="Field required"):
         _ = ConfigModel.model_validate(example_temporal_downscalers_config)
+
+
+def test_publication_meteogram_block_validates():
+    from evalml.config import ConfigModel
+
+    import yaml
+    from pathlib import Path
+
+    cfg = yaml.safe_load(
+        Path("config/Varda-Single_paper.yaml").read_text()
+    )
+    model = ConfigModel.model_validate(cfg)
+    assert model.publication.meteogram.init_time == "202504010000"
+    assert "DD_10M" in model.publication.meteogram.params

--- a/tests/unit/test_meteogram_derivations.py
+++ b/tests/unit/test_meteogram_derivations.py
@@ -1,0 +1,62 @@
+import numpy as np
+import xarray as xr
+
+from meteogram_derivations import (
+    add_derived,
+    expand_to_base_params,
+    station_timeseries_to_long,
+    wind_direction_deg,
+    wind_speed,
+)
+
+
+def test_expand_expands_derived_and_dedupes():
+    assert expand_to_base_params(["T_2M", "TOT_PREC", "SP_10M", "DD_10M"]) == [
+        "T_2M",
+        "TOT_PREC",
+        "U_10M",
+        "V_10M",
+    ]
+
+
+def test_expand_passes_through_non_derived():
+    assert expand_to_base_params(["T_2M", "U_10M"]) == ["T_2M", "U_10M"]
+
+
+def test_wind_speed_pythagoras():
+    assert wind_speed(3.0, 4.0) == 5.0
+
+
+def test_wind_direction_cardinals():
+    # meteorological: direction wind comes FROM
+    assert np.isclose(wind_direction_deg(0.0, -1.0), 0.0)   # from north
+    assert np.isclose(wind_direction_deg(-1.0, 0.0), 90.0)  # from east
+    assert np.isclose(wind_direction_deg(0.0, 1.0), 180.0)  # from south
+    assert np.isclose(wind_direction_deg(1.0, 0.0), 270.0)  # from west
+
+
+def test_wind_direction_in_range():
+    rng = np.linspace(-10, 10, 50)
+    u, v = np.meshgrid(rng, rng)
+    dd = wind_direction_deg(u, v)
+    assert np.all((dd >= 0) & (dd < 360))
+
+
+def test_add_derived_adds_requested_only():
+    ds = xr.Dataset({"U_10M": ("t", [3.0]), "V_10M": ("t", [4.0])})
+    out = add_derived(ds, ["SP_10M"])
+    assert np.isclose(out["SP_10M"].values[0], 5.0)
+    assert "DD_10M" not in out
+
+
+def test_station_timeseries_to_long_shape_and_columns():
+    times = np.array(["2025-04-01T00", "2025-04-01T01"], dtype="datetime64[h]")
+    ds = xr.Dataset(
+        {"T_2M": ("valid_time", [280.0, 281.0])},
+        coords={"valid_time": times},
+    )
+    df = station_timeseries_to_long(ds, "Varda-Single", ["T_2M", "TOT_PREC"])
+    assert list(df.columns) == ["source", "valid_time", "param", "value"]
+    assert set(df["param"]) == {"T_2M"}          # TOT_PREC absent -> skipped
+    assert len(df) == 2
+    assert df["source"].unique().tolist() == ["Varda-Single"]

--- a/tests/unit/test_meteogram_derivations.py
+++ b/tests/unit/test_meteogram_derivations.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import xarray as xr
 
 from meteogram_derivations import (
@@ -49,14 +50,34 @@ def test_add_derived_adds_requested_only():
     assert "DD_10M" not in out
 
 
+def test_add_derived_raises_without_uv():
+    ds = xr.Dataset({"T_2M": ("t", [280.0])})
+    with pytest.raises(ValueError, match="U_10M and V_10M"):
+        add_derived(ds, ["SP_10M"])
+
+
 def test_station_timeseries_to_long_shape_and_columns():
     times = np.array(["2025-04-01T00", "2025-04-01T01"], dtype="datetime64[h]")
     ds = xr.Dataset(
-        {"T_2M": ("valid_time", [280.0, 281.0])},
+        {"T_2M": ("valid_time", [280.0, 281.0]),
+         "TOT_PREC": ("valid_time", [0.0, 0.1])},
         coords={"valid_time": times},
     )
     df = station_timeseries_to_long(ds, "Varda-Single", ["T_2M", "TOT_PREC"])
     assert list(df.columns) == ["source", "valid_time", "param", "value"]
-    assert set(df["param"]) == {"T_2M"}          # TOT_PREC absent -> skipped
-    assert len(df) == 2
+    assert set(df["param"]) == {"T_2M", "TOT_PREC"}
+    assert len(df) == 4
     assert df["source"].unique().tolist() == ["Varda-Single"]
+
+
+def test_station_timeseries_to_long_raises_on_absent_param():
+    times = np.array(["2025-04-01T00"], dtype="datetime64[h]")
+    ds = xr.Dataset({"T_2M": ("valid_time", [280.0])}, coords={"valid_time": times})
+    with pytest.raises(KeyError, match="absent"):
+        station_timeseries_to_long(ds, "Varda-Single", ["T_2M", "TOT_PREC"])
+
+
+def test_station_timeseries_to_long_raises_without_time_coord():
+    ds = xr.Dataset({"T_2M": ("x", [280.0])}, coords={"x": [0]})
+    with pytest.raises(KeyError, match="valid_time' or 'time'"):
+        station_timeseries_to_long(ds, "Varda-Single", ["T_2M"])

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -227,11 +227,3 @@ rule verification_metrics_plot_all:
         ),
 
 
-rule publication_all:
-    """Target rule for publication figures workflow."""
-    input:
-        (
-            rules.publication_figures.output
-            if config.get("publication", {}).get("enabled", False)
-            else []
-        ),

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -260,3 +260,13 @@ rule verification_metrics_plot_all:
         ),
 
 
+rule publication_all:
+    """Target rule for publication figures workflow."""
+    input:
+        (
+            [rules.publication_figures.output, rules.publication_meteogram.output]
+            if config.get("publication", {}).get("enabled", False)
+            else []
+        ),
+
+

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -82,9 +82,11 @@ def parse_reference_times():
 def parse_regions():
     """Parse regions from the configuration."""
     cfg = config["experiment"]["stratification"]
-    regions = [f"{cfg['root']}/{region}.shp" for region in cfg["regions"]]
-    regions_txt = ",".join(regions)
-    return regions_txt
+    region_names = cfg.get("regions", [])
+    if not region_names:
+        return ""
+    regions = [f"{cfg['root']}/{region}.shp" for region in region_names]
+    return ",".join(regions)
 
 
 def parse_showcase_regions():

--- a/workflow/rules/inference.smk
+++ b/workflow/rules/inference.smk
@@ -36,8 +36,8 @@ rule inference_get_checkpoint:
                 fi
             elif [ "{params.checkpoint_type}" = "huggingface" ]; then
                 repo_id=$(python -c "import re; print(re.search(r'huggingface\.co/([^/]+/[^/]+)', '{params.checkpoint}').group(1))")
-                file_path=$(python -c "import re; print(re.search(r'huggingface\.co/[^/]+/[^/]+/blob/[^/]+/(.*)', '{params.checkpoint}').group(1))")
-                cp $(uvx hf download $repo_id $file_path) {output.checkpoint}
+                file_path=$(python -c "import re; print(re.search(r'huggingface\.co/[^/]+/[^/]+/(?:blob|resolve)/[^/]+/(.*)', '{params.checkpoint}').group(1))")
+                cp $(uvx hf download --quiet $repo_id $file_path) {output.checkpoint}
                 echo "Copied checkpoint from HuggingFace: {output.checkpoint}"
             elif [ "{params.checkpoint_type}" = "local" ]; then
                 ln -s {params.checkpoint} {output.checkpoint}

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -158,7 +158,8 @@ rule make_forecast_animation:
         delay=lambda wc: 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2]),
     shell:
         """
-        convert -delay {params.delay} -loop 0 {input} {output}
+        FRAMES=$(for f in {input}; do [ -s "$f" ] && echo "$f"; done | tr '\\n' ' ')
+        convert -delay {params.delay} -loop 0 $FRAMES {output}
         """
 
 

--- a/workflow/rules/publication.smk
+++ b/workflow/rules/publication.smk
@@ -3,6 +3,8 @@
 # ----------------------------------------------------- #
 rule publication_figures:
     input:
+        "workflow/scripts/publication_style.py",
+        "workflow/scripts/publication.mlpstyle",
         script="workflow/scripts/publication_figures.py",
         verif=EXPERIMENT_PARTICIPANTS.values(),
     output:
@@ -47,6 +49,8 @@ def _meteogram_baselines():
 
 rule publication_meteogram:
     input:
+        "workflow/scripts/publication_style.py",
+        "workflow/scripts/publication.mlpstyle",
         script="workflow/scripts/publication_meteogram.py",
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:

--- a/workflow/rules/publication.smk
+++ b/workflow/rules/publication.smk
@@ -7,7 +7,7 @@ rule publication_figures:
         verif=EXPERIMENT_PARTICIPANTS.values(),
     output:
         report(
-            directory("figures"),
+            directory("figures/leadtime"),
             htmlindex="publication_figures.html",
         ),
     log:
@@ -25,3 +25,69 @@ rule publication_figures:
             --sources "{params.labels}" \
             --output {output} > {log} 2>&1
         """
+
+
+def _meteogram_candidate_grib(wc):
+    """GRIB dir of the (single) candidate run for the configured init_time."""
+    run_id = list(CANDIDATES.keys())[0]
+    init_time = config["publication"]["meteogram"]["init_time"]
+    return str((Path(OUT_ROOT) / f"data/runs/{run_id}/{init_time}/grib").resolve())
+
+
+def _meteogram_baselines():
+    """Structured 'root|steps|member|label;...' for EPS-mean baselines."""
+    specs = []
+    for cfg in BASELINE_CONFIGS.values():
+        if cfg.get("member") == "mean":
+            specs.append(
+                f"{cfg['root']}|{cfg['steps']}|{cfg['member']}|{cfg['label']}"
+            )
+    return ";".join(specs)
+
+
+rule publication_meteogram:
+    input:
+        script="workflow/scripts/publication_meteogram.py",
+        peakweather_dir=rules.data_download_obs_from_peakweather.output.root,
+        eckit_grids=rules.data_download_eckit_geo_grids.output,
+    output:
+        report(
+            directory("figures/meteogram"),
+            htmlindex="publication_meteogram.html",
+        ),
+    log:
+        OUT_ROOT / "logs/figures/publication_meteogram.log",
+    localrule: True
+    params:
+        grib=_meteogram_candidate_grib,
+        forecast_steps=lambda wc: RUN_CONFIGS[list(CANDIDATES.keys())[0]]["steps"],
+        forecast_label=lambda wc: RUN_CONFIGS[list(CANDIDATES.keys())[0]]["label"],
+        baselines=_meteogram_baselines(),
+        date=config["publication"]["meteogram"]["init_time"],
+        station=config["publication"]["meteogram"]["station"],
+        params=",".join(config["publication"]["meteogram"]["params"]),
+    shell:
+        """
+        set -euo pipefail
+        export ECCODES_DEFINITION_PATH=$(realpath .venv/share/eccodes-cosmo-resources/definitions)
+        python {input.script} \
+            --forecast {params.grib:q} \
+            --forecast_steps {params.forecast_steps:q} \
+            --forecast_label {params.forecast_label:q} \
+            --baseline {params.baselines:q} \
+            --peakweather {input.peakweather_dir:q} \
+            --date {params.date:q} \
+            --station {params.station:q} \
+            --params {params.params:q} \
+            --output {output:q} > {log} 2>&1
+        """
+
+
+rule publication_all:
+    """Target rule for publication figures workflow."""
+    input:
+        (
+            [rules.publication_figures.output, rules.publication_meteogram.output]
+            if config.get("publication", {}).get("enabled", False)
+            else []
+        ),

--- a/workflow/rules/publication.smk
+++ b/workflow/rules/publication.smk
@@ -57,7 +57,11 @@ rule publication_meteogram:
         ),
     log:
         OUT_ROOT / "logs/figures/publication_meteogram.log",
-    localrule: True
+    resources:
+        slurm_partition="postproc",
+        cpus_per_task=8,
+        mem_mb=32000,
+        runtime="60m",
     params:
         grib=_meteogram_candidate_grib,
         forecast_steps=lambda wc: RUN_CONFIGS[list(CANDIDATES.keys())[0]]["steps"],

--- a/workflow/rules/publication.smk
+++ b/workflow/rules/publication.smk
@@ -85,13 +85,3 @@ rule publication_meteogram:
             --params {params.params:q} \
             --output {output:q} > {log} 2>&1
         """
-
-
-rule publication_all:
-    """Target rule for publication figures workflow."""
-    input:
-        (
-            [rules.publication_figures.output, rules.publication_meteogram.output]
-            if config.get("publication", {}).get("enabled", False)
-            else []
-        ),

--- a/workflow/rules/publication.smk
+++ b/workflow/rules/publication.smk
@@ -4,12 +4,12 @@
 rule publication_figures:
     input:
         "workflow/scripts/publication_style.py",
-        "workflow/scripts/publication.mlpstyle",
+        "workflow/scripts/publication.mplstyle",
         script="workflow/scripts/publication_figures.py",
         verif=EXPERIMENT_PARTICIPANTS.values(),
     output:
         report(
-            directory("figures/leadtime"),
+            directory(OUT_ROOT / "figures/leadtime"),
             htmlindex="publication_figures.html",
         ),
     log:
@@ -50,12 +50,12 @@ def _meteogram_baselines():
 rule publication_meteogram:
     input:
         "workflow/scripts/publication_style.py",
-        "workflow/scripts/publication.mlpstyle",
+        "workflow/scripts/publication.mplstyle",
         script="workflow/scripts/publication_meteogram.py",
         eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
         report(
-            directory("figures/meteogram"),
+            directory(OUT_ROOT / "figures/meteogram"),
             htmlindex="publication_meteogram.html",
         ),
     log:

--- a/workflow/scripts/meteogram_derivations.py
+++ b/workflow/scripts/meteogram_derivations.py
@@ -1,0 +1,76 @@
+"""Pure data derivations for the publication meteogram.
+
+No plotting, no file IO — kept importable and unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+# Display parameter -> base GRIB parameters required to compute it.
+_DERIVED: dict[str, list[str]] = {
+    "SP_10M": ["U_10M", "V_10M"],
+    "DD_10M": ["U_10M", "V_10M"],
+}
+
+
+def expand_to_base_params(display_params: list[str]) -> list[str]:
+    """Expand display params (may include derived SP_10M/DD_10M) to the base
+    params that must be loaded. Order-preserving and de-duplicated."""
+    base: list[str] = []
+    for p in display_params:
+        for bp in _DERIVED.get(p, [p]):
+            if bp not in base:
+                base.append(bp)
+    return base
+
+
+def wind_speed(u, v):
+    """10 m wind speed from u/v components (same units as the inputs)."""
+    return np.sqrt(u**2 + v**2)
+
+
+def wind_direction_deg(u, v):
+    """Meteorological wind direction in degrees, the direction the wind blows
+    FROM (0=N, 90=E, 180=S, 270=W). Returns values in [0, 360)."""
+    return (270.0 - np.rad2deg(np.arctan2(v, u))) % 360.0
+
+
+def add_derived(ds: xr.Dataset, display_params: list[str]) -> xr.Dataset:
+    """Add requested derived variables (SP_10M, DD_10M) to a dataset that holds
+    U_10M/V_10M. Base params are left untouched."""
+    ds = ds.copy()
+    have_uv = "U_10M" in ds and "V_10M" in ds
+    if "SP_10M" in display_params and have_uv:
+        ds["SP_10M"] = wind_speed(ds["U_10M"], ds["V_10M"])
+    if "DD_10M" in display_params and have_uv:
+        ds["DD_10M"] = wind_direction_deg(ds["U_10M"], ds["V_10M"])
+    return ds
+
+
+def station_timeseries_to_long(
+    ds: xr.Dataset, source: str, display_params: list[str]
+) -> pd.DataFrame:
+    """Flatten a single-station dataset to long form.
+
+    Returns columns [source, valid_time, param, value]. The time coordinate is
+    `valid_time` if present, else `time`. Params absent from `ds` are skipped.
+    """
+    tcoord = "valid_time" if "valid_time" in ds.coords or "valid_time" in ds.dims else "time"
+    frames: list[pd.DataFrame] = []
+    for p in display_params:
+        if p not in ds:
+            continue
+        da = ds[p].squeeze()
+        times = np.asarray(ds[tcoord].squeeze().values).reshape(-1)
+        values = np.asarray(da.values).reshape(-1)
+        frames.append(
+            pd.DataFrame(
+                {"source": source, "valid_time": times, "param": p, "value": values}
+            )
+        )
+    if not frames:
+        return pd.DataFrame(columns=["source", "valid_time", "param", "value"])
+    return pd.concat(frames, ignore_index=True)

--- a/workflow/scripts/meteogram_derivations.py
+++ b/workflow/scripts/meteogram_derivations.py
@@ -40,12 +40,21 @@ def wind_direction_deg(u, v):
 
 def add_derived(ds: xr.Dataset, display_params: list[str]) -> xr.Dataset:
     """Add requested derived variables (SP_10M, DD_10M) to a dataset that holds
-    U_10M/V_10M. Base params are left untouched."""
+    U_10M/V_10M. Base params are left untouched.
+
+    Raises ValueError if a derived wind parameter is requested but U_10M/V_10M
+    are not present to compute it (fail loudly rather than silently skipping).
+    """
     ds = ds.copy()
-    have_uv = "U_10M" in ds and "V_10M" in ds
-    if "SP_10M" in display_params and have_uv:
+    wanted = [p for p in ("SP_10M", "DD_10M") if p in display_params]
+    if wanted and not ("U_10M" in ds and "V_10M" in ds):
+        raise ValueError(
+            f"Cannot derive {wanted} without U_10M and V_10M "
+            f"(dataset has: {list(ds.data_vars)})."
+        )
+    if "SP_10M" in display_params:
         ds["SP_10M"] = wind_speed(ds["U_10M"], ds["V_10M"])
-    if "DD_10M" in display_params and have_uv:
+    if "DD_10M" in display_params:
         ds["DD_10M"] = wind_direction_deg(ds["U_10M"], ds["V_10M"])
     return ds
 
@@ -56,13 +65,28 @@ def station_timeseries_to_long(
     """Flatten a single-station dataset to long form.
 
     Returns columns [source, valid_time, param, value]. The time coordinate is
-    `valid_time` if present, else `time`. Params absent from `ds` are skipped.
+    `valid_time` if present, else `time`.
+
+    Raises KeyError if the dataset has no time coordinate, or if any requested
+    parameter is absent (fail loudly rather than silently skipping).
     """
-    tcoord = "valid_time" if "valid_time" in ds.coords or "valid_time" in ds.dims else "time"
+    if "valid_time" in ds.coords or "valid_time" in ds.dims:
+        tcoord = "valid_time"
+    elif "time" in ds.coords or "time" in ds.dims:
+        tcoord = "time"
+    else:
+        raise KeyError(
+            f"{source}: dataset has no 'valid_time' or 'time' coordinate "
+            f"(coords: {list(ds.coords)})."
+        )
+    missing = [p for p in display_params if p not in ds]
+    if missing:
+        raise KeyError(
+            f"{source}: requested parameters absent from dataset: {missing} "
+            f"(available: {list(ds.data_vars)})."
+        )
     frames: list[pd.DataFrame] = []
     for p in display_params:
-        if p not in ds:
-            continue
         da = ds[p].squeeze()
         times = np.asarray(ds[tcoord].squeeze().values).reshape(-1)
         values = np.asarray(da.values).reshape(-1)

--- a/workflow/scripts/plot_forecast_frame.py
+++ b/workflow/scripts/plot_forecast_frame.py
@@ -139,6 +139,17 @@ def main():
     grib_file = list(grib_dir.glob(f"2*_{lead_time}.grib"))
     if not grib_file:
         grib_file = list(grib_dir.glob(f"2*_{lead_time:03}.grib"))
+    if not grib_file:
+        LOG.warning(
+            "No GRIB file found for lead_time=%s in %s (model may not write initial state)."
+            " Creating empty placeholder frames.",
+            lead_time,
+            grib_dir,
+        )
+        for region_name in regions:
+            outfn = outdir / f"frame_{lead_time}_{param}_{region_name}.png"
+            outfn.touch()
+        return
     grib_file = Path(grib_file[0])
     LOG.info("Loading grib file %s", grib_file)
     state = load_state_from_grib(grib_file, paramlist=paramlist)
@@ -187,12 +198,13 @@ def main():
         plotter.plot_field(
             subplot, field, **get_style(param, units_override, accu=accu)
         )
-        subplot.ax.add_geometries(
-            state["lam_envelope"],
-            edgecolor="black",
-            facecolor="none",
-            crs=ccrs.PlateCarree(),
-        )
+        if len(state["lam_envelope"]) > 0:
+            subplot.ax.add_geometries(
+                state["lam_envelope"],
+                edgecolor="black",
+                facecolor="none",
+                crs=ccrs.PlateCarree(),
+            )
         fig.title(f"{param}, time: {validtime}")
 
         outfn = outdir / f"frame_{lead_time}_{param}_{region_name}.png"

--- a/workflow/scripts/publication.mplstyle
+++ b/workflow/scripts/publication.mplstyle
@@ -1,0 +1,19 @@
+## Publication figure style for evalml paper figures.
+## Apply with: plt.style.use(Path(__file__).parent / "publication.mplstyle")
+
+# Two-level font-size hierarchy:
+#   16 pt  — titles, axis labels, legend, suptitle  (identifies what is shown)
+#   13 pt  — tick values, in-panel annotations      (reads specific numbers)
+font.size           : 13    # base size for text() / annotate()
+axes.titlesize      : 16    # ax.set_title()
+axes.labelsize      : 16    # ax.set_xlabel() / ax.set_ylabel()
+xtick.labelsize     : 13
+ytick.labelsize     : 13
+legend.fontsize     : 16    # fig.legend() / ax.legend()
+figure.titlesize    : 16    # fig.suptitle()
+
+# Lines — overridden per-source by line_style() in publication_style.py
+lines.linewidth     : 1.5
+
+# Legend
+legend.frameon      : False

--- a/workflow/scripts/publication.mplstyle
+++ b/workflow/scripts/publication.mplstyle
@@ -9,7 +9,7 @@ axes.titlesize      : 16    # ax.set_title()
 axes.labelsize      : 16    # ax.set_xlabel() / ax.set_ylabel()
 xtick.labelsize     : 13
 ytick.labelsize     : 13
-legend.fontsize     : 16    # fig.legend() / ax.legend()
+legend.fontsize     : 13    # fig.legend() / ax.legend()
 figure.titlesize    : 16    # fig.suptitle()
 
 # Lines — overridden per-source by line_style() in publication_style.py

--- a/workflow/scripts/publication.mplstyle
+++ b/workflow/scripts/publication.mplstyle
@@ -6,7 +6,7 @@
 #   13 pt  — tick values, in-panel annotations      (reads specific numbers)
 font.size           : 13    # base size for text() / annotate()
 axes.titlesize      : 16    # ax.set_title()
-axes.labelsize      : 16    # ax.set_xlabel() / ax.set_ylabel()
+axes.labelsize      : 13    # ax.set_xlabel() / ax.set_ylabel()
 xtick.labelsize     : 13
 ytick.labelsize     : 13
 legend.fontsize     : 13    # fig.legend() / ax.legend()

--- a/workflow/scripts/publication_figures.py
+++ b/workflow/scripts/publication_figures.py
@@ -167,6 +167,10 @@ def _(Path, df_all, mo, output_dir, sources):
                 if _grp.empty:
                     continue
                 _ax.plot(_grp["step"], _grp["value"], label=_src, **line_style(_src))
+                if _src == "Varda-Single":
+                    _m6 = _grp[_grp["step"] % 6 == 0]
+                    _ax.plot(_m6["step"], _m6["value"], linestyle="none",
+                             marker="o", markersize=4, color=line_style(_src)["color"])
             _ax.set_xscale("function", **_xscale_kw)
             _ax.xaxis.set_major_locator(_xticks)
             if _row == 0:
@@ -189,6 +193,10 @@ def _(Path, df_all, mo, output_dir, sources):
             if _grp.empty:
                 continue
             _ax.plot(_grp["step"], _grp["value"], label=_src, **line_style(_src))
+            if "Varda" in _src and "Single" in _src:
+                _m6 = _grp[_grp["step"] % 6 == 0]
+                _ax.plot(_m6["step"], _m6["value"], linestyle="none",
+                         marker="o", markersize=4, color=line_style(_src)["color"])
         _ax.set_xscale("function", **_xscale_kw)
         _ax.xaxis.set_major_locator(_xticks)
         _panel_label = (

--- a/workflow/scripts/publication_figures.py
+++ b/workflow/scripts/publication_figures.py
@@ -109,6 +109,8 @@ def _(Path, df_all, mo, output_dir, sources):
     import matplotlib.ticker as mticker
     import numpy as np
 
+    from publication_style import line_style, param_label, FS_AXES, FS_TITLE
+
     _PARAMS = ["T_2M", "TOT_PREC", "U_10M"]
     _METRICS = ["BIAS", "RMSE"]
     # ETS panels: TOT_PREC > 0, TOT_PREC > 5.0, U_10M at largest threshold
@@ -133,24 +135,11 @@ def _(Path, df_all, mo, output_dir, sources):
         sharex=True,
     )
 
-    def _line_style(src):
-        color = (
-            "royalblue"     if "CH1" in src else
-            "seagreen"      if "CH2" in src else
-            "darkslategrey" if "Varda" in src else
-            "gray"
-        )
-        linestyle = "--" if "EPS mean" in src else "-"
-        linewidth = 2.25 if "Varda" in src else 1.5
-        return dict(color=color, linestyle=linestyle, linewidth=linewidth)
-
     _xscale_kw = dict(functions=(
         lambda x: np.sign(x) * np.abs(x) ** 0.7,
         lambda x: np.sign(x) * np.abs(x) ** (1 / 0.7),
     ))
     _xticks = mticker.FixedLocator([0, 3, 6, 12, 24, 36, 48, 72, 96, 120])
-    _FS_axes = 8   # unified font size for all axis labels and tick labels
-    _FS_title = 12 # unified font size for axis titles and legends
 
     # Rows 0…N-1: one panel per (metric, param)
     for _row, _metric in enumerate(_METRICS):
@@ -161,14 +150,14 @@ def _(Path, df_all, mo, output_dir, sources):
                 _grp = _data[_data["source"] == _src].sort_values("step")
                 if _grp.empty:
                     continue
-                _ax.plot(_grp["step"], _grp["value"], label=_src, **_line_style(_src))
+                _ax.plot(_grp["step"], _grp["value"], label=_src, **line_style(_src))
             _ax.set_xscale("function", **_xscale_kw)
             _ax.xaxis.set_major_locator(_xticks)
-            _ax.tick_params(labelsize=_FS_axes)
+            _ax.tick_params(labelsize=FS_AXES)
             if _row == 0:
-                _ax.set_title(_param, fontsize=_FS_title)
+                _ax.set_title(param_label(_param), fontsize=FS_TITLE)
             if _col == 0:
-                _ax.set_ylabel(_metric, fontsize=_FS_title)
+                _ax.set_ylabel(_metric, fontsize=FS_TITLE)
 
     # Last row: three specific ETS panels
     _ets_row = len(_METRICS)
@@ -182,22 +171,22 @@ def _(Path, df_all, mo, output_dir, sources):
             _grp = _data[_data["source"] == _src].sort_values("step")
             if _grp.empty:
                 continue
-            _ax.plot(_grp["step"], _grp["value"], label=_src, **_line_style(_src))
+            _ax.plot(_grp["step"], _grp["value"], label=_src, **line_style(_src))
         _ax.set_xscale("function", **_xscale_kw)
         _ax.xaxis.set_major_locator(_xticks)
-        _ax.tick_params(labelsize=_FS_axes)
-        _panel_label = _ets_metric.replace("ETS", _ets_param) + f" {_ets_unit}"
+        _ax.tick_params(labelsize=FS_AXES)
+        _panel_label = _ets_metric.replace("ETS", param_label(_ets_param)) + f" {_ets_unit}"
         _ax.text(0.97, 0.97, _panel_label, transform=_ax.transAxes,
-                 ha="right", va="top", fontsize=_FS_axes)
-        _ax.set_xlabel("Lead time (h)", fontsize=_FS_axes)
+                 ha="right", va="top", fontsize=FS_AXES)
+        _ax.set_xlabel("Lead time (h)", fontsize=FS_AXES)
         if _col == 0:
-            _ax.set_ylabel("ETS", fontsize=_FS_title)
+            _ax.set_ylabel("ETS", fontsize=FS_TITLE)
 
     _axes[0, 0].set_xlim(-1, 126)
 
     _handles, _labels = _axes[0, 0].get_legend_handles_labels()
     _fig.legend(_handles, _labels, loc="lower center", ncol=len(sources),
-                fontsize=_FS_title, frameon=False, bbox_to_anchor=(0.5, 0.06))
+                fontsize=FS_TITLE, frameon=False, bbox_to_anchor=(0.5, 0.06))
     _fig.tight_layout()
     _fig.subplots_adjust(bottom=0.22)
 
@@ -207,33 +196,41 @@ def _(Path, df_all, mo, output_dir, sources):
         _pos = _axes[_ets_row, _c].get_position()
         _axes[_ets_row, _c].set_position([_pos.x0, _pos.y0 - _extra_gap, _pos.width, _pos.height])
 
-    # Light-grey background encompassing the four TOT_PREC panels and their labels.
-    # Axes keep a white background; the grey appears only in the margins around them.
-    _PREC_BG   = "#f0f0f0"
-    _pad_left  = 0.040  # horizontal padding beyond axes left edges
-    _pad_bleft = 0.025  # horizontal padding beyond axes for lower left
-    _pad_right = 0.010  # horizontal padding beyond axes right edges
-    _pad_top   = 0.040  # above row-0 axes to capture the column title
-    _pad_bot   = 0.050  # below ETS row to capture the x-axis label
-    _pad_mid   = 0.010
+    # Light-grey background behind the TOT_PREC panels (incl. their titles/labels).
+    # Derived from the axes' *tight* bounding boxes so it stays aligned at any
+    # font size. Two overlapping rectangles form the stepped shape: a narrow one
+    # over the TOT_PREC metric column (col 1) and a wider one under the two
+    # TOT_PREC ETS panels (cols 0-1). Axes keep white faces, so grey shows only
+    # in the margins around them.
+    from matplotlib.patches import Rectangle as _Rect
 
-    from matplotlib.patches import Polygon as _MplPolygon
-    _m0_pos = _axes[0, 1].get_position()                    # top of metric col 1
-    _m_pos  = _axes[len(_METRICS) - 1, 1].get_position()    # bottom of metric col 1
-    _e0_pos = _axes[_ets_row, 0].get_position()             # ETS col 0
-    _e1_pos = _axes[_ets_row, 1].get_position()             # ETS col 1
-    _trap = _MplPolygon([
-        (_m0_pos.x0 - _pad_left, _m0_pos.y1 + _pad_top),    # top-left (above col-1, row-0)
-        (_m0_pos.x1 + _pad_right, _m0_pos.y1 + _pad_top),   # top-right
-        (_m_pos.x1  + _pad_right, _m_pos.y0),               # bottom-right of metric area
-        (_e1_pos.x1 + _pad_right, _e0_pos.y1 - _pad_mid),   # top-right of ETS area
-        (_e1_pos.x1 + _pad_right, _e0_pos.y0 - _pad_bot),   # bottom-right (incl. x-label)
-        (_e0_pos.x0 - _pad_bleft, _e0_pos.y0 - _pad_bot),   # bottom-left
-        (_e0_pos.x0 - _pad_bleft, _e0_pos.y1 + _pad_mid),   # top-left of ETS area
-        (_m_pos.x0  - _pad_left, _m_pos.y0),                # bottom-left of metric area
-    ], closed=True, facecolor=_PREC_BG, edgecolor="none", zorder=-1)
-    _trap.set_transform(_fig.transFigure)
-    _fig.add_artist(_trap)
+    _PREC_BG = "#f0f0f0"
+    _pad = 0.008
+
+    _fig.canvas.draw()  # ensure renderer + final positions for tight bboxes
+    _rend = _fig.canvas.get_renderer()
+    _inv = _fig.transFigure.inverted()
+
+    def _union_bbox(_axs):
+        _pts = [_inv.transform(_a.get_tightbbox(_rend).get_points()) for _a in _axs]
+        return (
+            min(_p[0][0] for _p in _pts), min(_p[0][1] for _p in _pts),
+            max(_p[1][0] for _p in _pts), max(_p[1][1] for _p in _pts),
+        )
+
+    _ux0, _uy0, _ux1, _uy1 = _union_bbox([_axes[_r, 1] for _r in range(len(_METRICS))])
+    _lx0, _ly0, _lx1, _ly1 = _union_bbox([_axes[_ets_row, 0], _axes[_ets_row, 1]])
+    _mid = (_uy0 + _ly1) / 2  # split point in the gap between metric and ETS blocks
+    for _x0, _y0, _x1, _y1 in [
+        (_ux0, _mid, _ux1, _uy1),   # upper block (col 1)
+        (_lx0, _ly0, _lx1, _mid),   # lower block (cols 0-1), overlaps at _mid
+    ]:
+        _fig.add_artist(_Rect(
+            (_x0 - _pad, _y0 - _pad),
+            (_x1 - _x0) + 2 * _pad, (_y1 - _y0) + 2 * _pad,
+            facecolor=_PREC_BG, edgecolor="none", zorder=-1,
+            transform=_fig.transFigure,
+        ))
 
     _fname = _out / "publication_figures_leadtime.pdf"
     _fig.savefig(_fname, bbox_inches="tight")

--- a/workflow/scripts/publication_figures.py
+++ b/workflow/scripts/publication_figures.py
@@ -12,7 +12,7 @@ def _():
 
     _script_dir = Path(__file__).resolve().parent  # workflow/scripts/
     sys.path.append(str(_script_dir))
-    project_root = _script_dir.parent.parent        # repo root
+    project_root = _script_dir.parent.parent  # repo root
     return Path, mo, project_root, sys
 
 
@@ -25,11 +25,14 @@ def _(mo, sys):
         " output/data/baselines/baseline-e0f0/verif_aggregated_2b83.nc"
         " output/data/runs/temporal_downscaler-f927-1ee3-on-forecaster-c304-23e7/495c/verif_aggregated_2b83.nc"
     )
-    _SOURCE_DEFAULT = "ICON-CH1-CTRL,ICON-CH2-CTRL,ICON-CH1-EPS mean,ICON-CH2-EPS mean,Varda-Single"
+    _SOURCE_DEFAULT = (
+        "ICON-CH1-CTRL,ICON-CH2-CTRL,ICON-CH1-EPS mean,ICON-CH2-EPS mean,Varda-Single"
+    )
 
     _cli = mo.cli_args()
     if not _cli and len(sys.argv) > 1:
         import argparse
+
         _p = argparse.ArgumentParser()
         _p.add_argument("--verif_files", default=_VERIF_DEFAULT)
         _p.add_argument("--sources", default=_SOURCE_DEFAULT)
@@ -45,8 +48,12 @@ def _(mo, sys):
         _default_output = _cli.get("output", default="figures/debug")
         _is_script = bool(_cli)
 
-    verif_input = mo.ui.text(value=_default_verif, label="Verification files (space-separated)")
-    sources_input = mo.ui.text(value=_default_sources, label="Sources (comma-separated)")
+    verif_input = mo.ui.text(
+        value=_default_verif, label="Verification files (space-separated)"
+    )
+    sources_input = mo.ui.text(
+        value=_default_sources, label="Sources (comma-separated)"
+    )
     output_input = mo.ui.text(value=_default_output, label="Output directory")
 
     mo.vstack([verif_input, sources_input, output_input]) if not _is_script else None
@@ -96,9 +103,7 @@ def _(Path, project_root, verif_files):
 def _(df):
     # Filter to aggregated-over-all-strata slice for overview plots
     df_all = df[
-        (df["region"] == "all") &
-        (df["season"] == "all") &
-        (df["init_hour"] == "all")
+        (df["region"] == "all") & (df["season"] == "all") & (df["init_hour"] == "all")
     ].copy()
     return (df_all,)
 
@@ -109,36 +114,47 @@ def _(Path, df_all, mo, output_dir, sources):
     import matplotlib.ticker as mticker
     import numpy as np
 
-    from publication_style import line_style, param_label, FS_AXES, FS_TITLE
+    from publication_style import line_style, param_label
+
+    plt.style.use(Path(__file__).resolve().parent / "publication.mplstyle")
 
     _PARAMS = ["T_2M", "TOT_PREC", "U_10M"]
     _METRICS = ["BIAS", "RMSE"]
     # ETS panels: TOT_PREC > 0, TOT_PREC > 5.0, U_10M at largest threshold
-    _prec_ets = sorted(m for m in df_all[df_all["param"] == "TOT_PREC"]["metric"].unique() if "ETS" in m)
-    _wind_ets = sorted(m for m in df_all[df_all["param"] == "U_10M"]["metric"].unique() if "ETS" in m)
+    _prec_ets = sorted(
+        m
+        for m in df_all[df_all["param"] == "TOT_PREC"]["metric"].unique()
+        if "ETS" in m
+    )
+    _wind_ets = sorted(
+        m for m in df_all[df_all["param"] == "U_10M"]["metric"].unique() if "ETS" in m
+    )
 
     def _find_ets(metrics, threshold):
         return next((m for m in metrics if m.endswith(f"> {threshold}")), None)
 
     _ets_panels = [
-        ("TOT_PREC", _find_ets(_prec_ets, "0.0"),   "mm"),
+        ("TOT_PREC", _find_ets(_prec_ets, "0.0"), "mm"),
         ("TOT_PREC", _find_ets(_prec_ets, "5.0"), "mm"),
-        ("U_10M",    _wind_ets[-1] if _wind_ets else None, "m/s"),
+        ("U_10M", _wind_ets[-1] if _wind_ets else None, "m/s"),
     ]
 
     _out = Path(output_dir)
     _out.mkdir(parents=True, exist_ok=True)
 
     _fig, _axes = plt.subplots(
-        len(_METRICS) + 1, len(_PARAMS),
+        len(_METRICS) + 1,
+        len(_PARAMS),
         figsize=(4 * len(_PARAMS), 3 * (len(_METRICS) + 1)),
         sharex=True,
     )
 
-    _xscale_kw = dict(functions=(
-        lambda x: np.sign(x) * np.abs(x) ** 0.7,
-        lambda x: np.sign(x) * np.abs(x) ** (1 / 0.7),
-    ))
+    _xscale_kw = dict(
+        functions=(
+            lambda x: np.sign(x) * np.abs(x) ** 0.7,
+            lambda x: np.sign(x) * np.abs(x) ** (1 / 0.7),
+        )
+    )
     _xticks = mticker.FixedLocator([0, 3, 6, 12, 24, 36, 48, 72, 96, 120])
 
     # Rows 0…N-1: one panel per (metric, param)
@@ -153,11 +169,10 @@ def _(Path, df_all, mo, output_dir, sources):
                 _ax.plot(_grp["step"], _grp["value"], label=_src, **line_style(_src))
             _ax.set_xscale("function", **_xscale_kw)
             _ax.xaxis.set_major_locator(_xticks)
-            _ax.tick_params(labelsize=FS_AXES)
             if _row == 0:
-                _ax.set_title(param_label(_param), fontsize=FS_TITLE)
+                _ax.set_title(param_label(_param))
             if _col == 0:
-                _ax.set_ylabel(_metric, fontsize=FS_TITLE)
+                _ax.set_ylabel(_metric)
 
     # Last row: three specific ETS panels
     _ets_row = len(_METRICS)
@@ -166,7 +181,9 @@ def _(Path, df_all, mo, output_dir, sources):
         if _ets_metric is None:
             _ax.set_visible(False)
             continue
-        _data = df_all[(df_all["param"] == _ets_param) & (df_all["metric"] == _ets_metric)]
+        _data = df_all[
+            (df_all["param"] == _ets_param) & (df_all["metric"] == _ets_metric)
+        ]
         for _src in sources:
             _grp = _data[_data["source"] == _src].sort_values("step")
             if _grp.empty:
@@ -174,19 +191,26 @@ def _(Path, df_all, mo, output_dir, sources):
             _ax.plot(_grp["step"], _grp["value"], label=_src, **line_style(_src))
         _ax.set_xscale("function", **_xscale_kw)
         _ax.xaxis.set_major_locator(_xticks)
-        _ax.tick_params(labelsize=FS_AXES)
-        _panel_label = _ets_metric.replace("ETS", param_label(_ets_param)) + f" {_ets_unit}"
-        _ax.text(0.97, 0.97, _panel_label, transform=_ax.transAxes,
-                 ha="right", va="top", fontsize=FS_AXES)
-        _ax.set_xlabel("Lead time (h)", fontsize=FS_AXES)
+        _panel_label = (
+            _ets_metric.replace("ETS", param_label(_ets_param)) + f" {_ets_unit}"
+        )
+        _ax.text(
+            0.97, 0.97, _panel_label, transform=_ax.transAxes, ha="right", va="top"
+        )
+        _ax.set_xlabel("Lead time (h)")
         if _col == 0:
-            _ax.set_ylabel("ETS", fontsize=FS_TITLE)
+            _ax.set_ylabel("ETS")
 
     _axes[0, 0].set_xlim(-1, 126)
 
     _handles, _labels = _axes[0, 0].get_legend_handles_labels()
-    _fig.legend(_handles, _labels, loc="lower center", ncol=len(sources),
-                fontsize=FS_TITLE, frameon=False, bbox_to_anchor=(0.5, 0.06))
+    _fig.legend(
+        _handles,
+        _labels,
+        loc="lower center",
+        ncol=len(sources),
+        bbox_to_anchor=(0.5, 0.06),
+    )
     _fig.tight_layout()
     _fig.subplots_adjust(bottom=0.22)
 
@@ -194,7 +218,9 @@ def _(Path, df_all, mo, output_dir, sources):
     _extra_gap = 0.04
     for _c in range(len(_PARAMS)):
         _pos = _axes[_ets_row, _c].get_position()
-        _axes[_ets_row, _c].set_position([_pos.x0, _pos.y0 - _extra_gap, _pos.width, _pos.height])
+        _axes[_ets_row, _c].set_position(
+            [_pos.x0, _pos.y0 - _extra_gap, _pos.width, _pos.height]
+        )
 
     # Light-grey background behind the TOT_PREC panels (incl. their titles/labels).
     # Derived from the axes' *tight* bounding boxes so it stays aligned at any
@@ -214,23 +240,30 @@ def _(Path, df_all, mo, output_dir, sources):
     def _union_bbox(_axs):
         _pts = [_inv.transform(_a.get_tightbbox(_rend).get_points()) for _a in _axs]
         return (
-            min(_p[0][0] for _p in _pts), min(_p[0][1] for _p in _pts),
-            max(_p[1][0] for _p in _pts), max(_p[1][1] for _p in _pts),
+            min(_p[0][0] for _p in _pts),
+            min(_p[0][1] for _p in _pts),
+            max(_p[1][0] for _p in _pts),
+            max(_p[1][1] for _p in _pts),
         )
 
     _ux0, _uy0, _ux1, _uy1 = _union_bbox([_axes[_r, 1] for _r in range(len(_METRICS))])
     _lx0, _ly0, _lx1, _ly1 = _union_bbox([_axes[_ets_row, 0], _axes[_ets_row, 1]])
     _mid = (_uy0 + _ly1) / 2  # split point in the gap between metric and ETS blocks
     for _x0, _y0, _x1, _y1 in [
-        (_ux0, _mid, _ux1, _uy1),   # upper block (col 1)
-        (_lx0, _ly0, _lx1, _mid),   # lower block (cols 0-1), overlaps at _mid
+        (_ux0, _mid, _ux1, _uy1),  # upper block (col 1)
+        (_lx0, _ly0, _lx1, _mid),  # lower block (cols 0-1), overlaps at _mid
     ]:
-        _fig.add_artist(_Rect(
-            (_x0 - _pad, _y0 - _pad),
-            (_x1 - _x0) + 2 * _pad, (_y1 - _y0) + 2 * _pad,
-            facecolor=_PREC_BG, edgecolor="none", zorder=-1,
-            transform=_fig.transFigure,
-        ))
+        _fig.add_artist(
+            _Rect(
+                (_x0 - _pad, _y0 - _pad),
+                (_x1 - _x0) + 2 * _pad,
+                (_y1 - _y0) + 2 * _pad,
+                facecolor=_PREC_BG,
+                edgecolor="none",
+                zorder=-1,
+                transform=_fig.transFigure,
+            )
+        )
 
     _fname = _out / "publication_figures_leadtime.pdf"
     _fig.savefig(_fname, bbox_inches="tight")
@@ -238,9 +271,9 @@ def _(Path, df_all, mo, output_dir, sources):
     plt.close(_fig)
 
     (_out / "publication_figures.html").write_text(
-        f'<!doctype html><html><body>'
-        f'<img src="publication_figures_leadtime.png" style="max-width:100%">'
-        f'</body></html>'
+        "<!doctype html><html><body>"
+        '<img src="publication_figures_leadtime.png" style="max-width:100%">'
+        "</body></html>"
     )
 
     mo.image(str(_fname.with_suffix(".png")))

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -129,7 +129,7 @@ def _(
         p = Path(p)
         return p if p.is_absolute() else project_root / p
 
-    init_time = datetime.strptime(date, "%Y%m%d%H%M")
+    init_time = datetime.strptime(str(date), "%Y%m%d%H%M")
     base_params = expand_to_base_params(display_params)
 
     # Observations (already at stations) -> reuse one station as the mapping target.

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -18,6 +18,19 @@ def _():
 
 
 @app.cell
+def _():
+    import logging
+    import time
+
+    LOG = logging.getLogger(__name__)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    return (LOG,)
+
+
+@app.cell
 def _(mo, sys):
     # Interactive defaults point at the copied dataset so the notebook runs as-is.
     _RUN = "output/data/runs/temporal_downscaler-f927-1ee3-on-forecaster-c304-23e7/495c"
@@ -94,6 +107,7 @@ def _(baselines_raw, params_raw):
 
 @app.cell
 def _(
+    LOG,
     Path,
     baselines,
     date,
@@ -130,30 +144,33 @@ def _(
     init_time = datetime.strptime(str(date), "%Y%m%d%H%M")
     base_params = expand_to_base_params(display_params)
 
-    # Observations from the MeteoSwiss DWH (jretrievedwh marker, e.g.
-    # "jretrievedwh:locations=KLO"). Returns dims (time, values) with lat/lon
-    # coords, same shape as the gridded->station mapping target.
+    LOG.info("meteogram: loading observations from %s", obs_source)
+    _t0 = time.perf_counter()
     obs_steps = parse_steps(forecast_steps)
     obs = load_obs_data_from_jretrieve(
         obs_source, init_time, obs_steps, base_params
     )
     obs_station = add_derived(obs.sel(values=[station]), display_params)
-    # Mapping target: keep lat/lon coords, drop only the data variables
-    # (obs[[]] would also strip the non-dimension lat/lon coords).
     _sel = obs.sel(values=[station])
     station_target = _sel.drop_vars(list(_sel.data_vars))
+    LOG.info("meteogram: observations loaded in %.1fs", time.perf_counter() - _t0)
 
     frames = [station_timeseries_to_long(obs_station, OBS_LABEL, display_params)]
 
-    # Candidate (ML GRIB) -> map to station -> derive.
+    LOG.info("meteogram: loading candidate forecast from %s", forecast)
+    _t0 = time.perf_counter()
     cand = load_forecast_data(
         _abs(forecast), init_time, parse_steps(forecast_steps), base_params
     )
+    LOG.info("meteogram: candidate GRIB loaded in %.1fs", time.perf_counter() - _t0)
+    _t0 = time.perf_counter()
     cand_st = add_derived(map_forecast_to_truth(cand, station_target), display_params)
+    LOG.info("meteogram: candidate remapped to station in %.1fs", time.perf_counter() - _t0)
     frames.append(station_timeseries_to_long(cand_st, forecast_label, display_params))
 
-    # EPS-mean baselines -> map -> derive.
     for b in baselines:
+        LOG.info("meteogram: loading baseline %s from %s", b["label"], b["root"])
+        _t0 = time.perf_counter()
         bds = load_forecast_data(
             Path(b["root"]),
             init_time,
@@ -161,7 +178,10 @@ def _(
             base_params,
             member=b["member"],
         )
+        LOG.info("meteogram: baseline %s loaded in %.1fs", b["label"], time.perf_counter() - _t0)
+        _t0 = time.perf_counter()
         bst = add_derived(map_forecast_to_truth(bds, station_target), display_params)
+        LOG.info("meteogram: baseline %s remapped in %.1fs", b["label"], time.perf_counter() - _t0)
         frames.append(station_timeseries_to_long(bst, b["label"], display_params))
 
     df = pd.concat(frames, ignore_index=True)
@@ -171,6 +191,7 @@ def _(
 
 @app.cell
 def _(
+    LOG,
     OBS_LABEL,
     Path,
     df,
@@ -186,6 +207,8 @@ def _(
 
     from publication_style import line_style, param_label
 
+    LOG.info("meteogram: rendering plot")
+    _t0 = time.perf_counter()
     plt.style.use(Path(__file__).resolve().parent / "publication.mplstyle")
 
     _UNITS = {"T_2M": "K", "TOT_PREC": "mm", "SP_10M": "m/s", "DD_10M": "deg"}
@@ -242,12 +265,17 @@ def _(
     _fig.suptitle(f"{station} — Init time {init_time:%Y-%m-%d %H:%M}")
     _fig.tight_layout(rect=[0, 0.05, 1, 0.99])
 
+    LOG.info("meteogram: plot rendered in %.1fs", time.perf_counter() - _t0)
+
     _out = Path(output_dir)
     _out.mkdir(parents=True, exist_ok=True)
     _fname = _out / "publication_meteogram.pdf"
+    LOG.info("meteogram: saving figures to %s", _out)
+    _t0 = time.perf_counter()
     _fig.savefig(_fname, bbox_inches="tight")
     _fig.savefig(_fname.with_suffix(".png"), dpi=200, bbox_inches="tight")
     plt.close(_fig)
+    LOG.info("meteogram: figures saved in %.1fs", time.perf_counter() - _t0)
     (_out / "publication_meteogram.html").write_text(
         "<!doctype html><html><body>"
         '<img src="publication_meteogram.png" style="max-width:100%">'

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -1,0 +1,234 @@
+import marimo
+
+__generated_with = "0.23.9"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import sys
+    from pathlib import Path
+
+    import marimo as mo
+
+    _script_dir = Path(__file__).resolve().parent  # workflow/scripts/
+    sys.path.append(str(_script_dir))
+    project_root = _script_dir.parent.parent
+    return Path, mo, project_root, sys
+
+
+@app.cell
+def _(mo, sys):
+    # Interactive defaults point at the copied dataset so the notebook runs as-is.
+    _RUN = "output/data/runs/temporal_downscaler-f927-1ee3-on-forecaster-c304-23e7/495c"
+    _FORECAST_DEFAULT = f"{_RUN}/202504010000/grib"
+    _BASELINES_DEFAULT = (
+        "/store_new/mch/msopr/osm/ICON-CH1-EPS|0/33/1|mean|ICON-CH1-EPS mean;"
+        "/store_new/mch/msopr/osm/ICON-CH2-EPS|0/120/1|mean|ICON-CH2-EPS mean"
+    )
+    _PW_DEFAULT = "output/data/observations/peakweather"
+
+    _cli = mo.cli_args()
+    if not _cli and len(sys.argv) > 1:
+        import argparse
+
+        _p = argparse.ArgumentParser()
+        _p.add_argument("--forecast", default=_FORECAST_DEFAULT)
+        _p.add_argument("--forecast_steps", default="0/120/1")
+        _p.add_argument("--forecast_label", default="Varda-Single")
+        _p.add_argument("--baseline", action="append", default=None)
+        _p.add_argument("--peakweather", default=_PW_DEFAULT)
+        _p.add_argument("--date", default="202504010000")
+        _p.add_argument("--station", default="KLO")
+        _p.add_argument("--params", default="T_2M,TOT_PREC,SP_10M,DD_10M")
+        _p.add_argument("--output", default="figures/meteogram")
+        _a, _ = _p.parse_known_args()
+        forecast = _a.forecast
+        forecast_steps = _a.forecast_steps
+        forecast_label = _a.forecast_label
+        baselines_raw = ";".join(_a.baseline) if _a.baseline else _BASELINES_DEFAULT
+        peakweather = _a.peakweather
+        date = _a.date
+        station = _a.station
+        params_raw = _a.params
+        output_dir = _a.output
+        _is_script = True
+    else:
+        forecast = _cli.get("forecast", default=_FORECAST_DEFAULT)
+        forecast_steps = _cli.get("forecast_steps", default="0/120/1")
+        forecast_label = _cli.get("forecast_label", default="Varda-Single")
+        baselines_raw = _cli.get("baselines", default=_BASELINES_DEFAULT)
+        peakweather = _cli.get("peakweather", default=_PW_DEFAULT)
+        date = _cli.get("date", default="202504010000")
+        station = _cli.get("station", default="KLO")
+        params_raw = _cli.get("params", default="T_2M,TOT_PREC,SP_10M,DD_10M")
+        output_dir = _cli.get("output", default="figures/meteogram")
+        _is_script = bool(_cli)
+    return (
+        baselines_raw,
+        date,
+        forecast,
+        forecast_label,
+        forecast_steps,
+        output_dir,
+        params_raw,
+        peakweather,
+        station,
+    )
+
+
+@app.cell
+def _(baselines_raw, params_raw):
+    # Parse the structured baseline string: "root|steps|member|label;root|..."
+    def _parse_baselines(raw):
+        out = []
+        for spec in [s for s in raw.split(";") if s.strip()]:
+            root, steps, member, label = spec.split("|")
+            out.append(
+                {"root": root, "steps": steps, "member": member, "label": label}
+            )
+        return out
+
+    baselines = _parse_baselines(baselines_raw)
+    display_params = [p.strip() for p in params_raw.split(",") if p.strip()]
+    return baselines, display_params
+
+
+@app.cell
+def _(
+    Path,
+    baselines,
+    date,
+    display_params,
+    forecast,
+    forecast_label,
+    forecast_steps,
+    peakweather,
+    project_root,
+    station,
+):
+    from datetime import datetime
+
+    from data_input import (
+        load_forecast_data,
+        load_obs_data_from_peakweather,
+        parse_steps,
+    )
+    from meteogram_derivations import (
+        add_derived,
+        expand_to_base_params,
+        station_timeseries_to_long,
+    )
+    from verification.spatial import map_forecast_to_truth
+
+    import pandas as pd
+
+    OBS_LABEL = "Observations"
+
+    def _abs(p):
+        p = Path(p)
+        return p if p.is_absolute() else project_root / p
+
+    init_time = datetime.strptime(date, "%Y%m%d%H%M")
+    base_params = expand_to_base_params(display_params)
+
+    # Observations (already at stations) -> reuse one station as the mapping target.
+    obs_steps = parse_steps(forecast_steps)
+    obs = load_obs_data_from_peakweather(
+        _abs(peakweather), init_time, obs_steps, base_params
+    )
+    obs_station = add_derived(obs.sel(values=[station]), display_params)
+    station_target = obs.sel(values=[station])[[]]  # coords (lat/lon) only
+
+    frames = [station_timeseries_to_long(obs_station, OBS_LABEL, display_params)]
+
+    # Candidate (ML GRIB) -> map to station -> derive.
+    cand = load_forecast_data(
+        _abs(forecast), init_time, parse_steps(forecast_steps), base_params
+    )
+    cand_st = add_derived(map_forecast_to_truth(cand, station_target), display_params)
+    frames.append(station_timeseries_to_long(cand_st, forecast_label, display_params))
+
+    # EPS-mean baselines -> map -> derive.
+    for b in baselines:
+        bds = load_forecast_data(
+            Path(b["root"]),
+            init_time,
+            parse_steps(b["steps"]),
+            base_params,
+            member=b["member"],
+        )
+        bst = add_derived(map_forecast_to_truth(bds, station_target), display_params)
+        frames.append(station_timeseries_to_long(bst, b["label"], display_params))
+
+    df = pd.concat(frames, ignore_index=True)
+    source_order = [OBS_LABEL] + [b["label"] for b in baselines] + [forecast_label]
+    return OBS_LABEL, df, init_time, source_order
+
+
+@app.cell
+def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_order, station):
+    import matplotlib.pyplot as plt
+
+    _UNITS = {"T_2M": "K", "TOT_PREC": "mm", "SP_10M": "m/s", "DD_10M": "deg"}
+    _FS_axes = 8
+    _FS_title = 12
+
+    def _line_style(src):
+        if src == OBS_LABEL:
+            return dict(color="black", linestyle="none", marker="o", markersize=3)
+        color = (
+            "royalblue" if "CH1" in src else
+            "seagreen" if "CH2" in src else
+            "darkslategrey" if "Varda" in src else
+            "gray"
+        )
+        linestyle = "--" if "EPS mean" in src else "-"
+        linewidth = 2.25 if "Varda" in src else 1.5
+        return dict(color=color, linestyle=linestyle, linewidth=linewidth)
+
+    _fig, _axes = plt.subplots(
+        len(display_params), 1,
+        figsize=(8, 2.6 * len(display_params)),
+        sharex=True,
+    )
+    if len(display_params) == 1:
+        _axes = [_axes]
+
+    for _ax, _p in zip(_axes, display_params):
+        _sub = df[df["param"] == _p]
+        for _src in source_order:
+            _g = _sub[_sub["source"] == _src].sort_values("valid_time")
+            if _g.empty:
+                continue
+            _ax.plot(_g["valid_time"], _g["value"], label=_src, **_line_style(_src))
+        _ax.set_ylabel(_UNITS.get(_p, _p), fontsize=_FS_title)
+        _ax.tick_params(labelsize=_FS_axes)
+        _ax.text(0.01, 0.97, _p, transform=_ax.transAxes,
+                 ha="left", va="top", fontsize=_FS_axes)
+
+    _axes[-1].set_xlabel("Valid time", fontsize=_FS_axes)
+    _handles, _labels = _axes[0].get_legend_handles_labels()
+    _fig.legend(_handles, _labels, loc="lower center", ncol=len(source_order),
+                fontsize=_FS_title, frameon=False, bbox_to_anchor=(0.5, 0.0))
+    _fig.suptitle(f"{station} — init {init_time:%Y-%m-%d %H:%M}", fontsize=_FS_title)
+    _fig.tight_layout(rect=[0, 0.05, 1, 0.99])
+
+    _out = Path(output_dir)
+    _out.mkdir(parents=True, exist_ok=True)
+    _fname = _out / "publication_meteogram.pdf"
+    _fig.savefig(_fname, bbox_inches="tight")
+    _fig.savefig(_fname.with_suffix(".png"), dpi=200, bbox_inches="tight")
+    plt.close(_fig)
+    (_out / "publication_meteogram.html").write_text(
+        '<!doctype html><html><body>'
+        '<img src="publication_meteogram.png" style="max-width:100%">'
+        '</body></html>'
+    )
+
+    mo.image(str(_fname.with_suffix(".png")))
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -123,7 +123,7 @@ def _(
 
     import pandas as pd
 
-    OBS_LABEL = "Observations"
+    from publication_style import OBS_LABEL
 
     def _abs(p):
         p = Path(p)
@@ -174,22 +174,9 @@ def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_ord
     import matplotlib.pyplot as plt
     import matplotlib.ticker as mticker
 
-    _UNITS = {"T_2M": "K", "TOT_PREC": "mm", "SP_10M": "m/s", "DD_10M": "deg"}
-    _FS_axes = 13
-    _FS_title = 16
+    from publication_style import line_style, param_label, FS_AXES, FS_TITLE
 
-    def _line_style(src):
-        if src == OBS_LABEL:
-            return dict(color="red", linestyle="none", marker="o", markersize=3)
-        color = (
-            "royalblue" if "CH1" in src else
-            "seagreen" if "CH2" in src else
-            "darkslategrey" if "Varda" in src else
-            "gray"
-        )
-        linestyle = "--" if "EPS mean" in src else "-"
-        linewidth = 2.25 if "Varda" in src else 1.5
-        return dict(color=color, linestyle=linestyle, linewidth=linewidth)
+    _UNITS = {"T_2M": "K", "TOT_PREC": "mm", "SP_10M": "m/s", "DD_10M": "deg"}
 
     _fig, _axes = plt.subplots(
         len(display_params), 1,
@@ -205,17 +192,17 @@ def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_ord
             _g = _sub[_sub["source"] == _src].sort_values("valid_time")
             if _g.empty:
                 continue
-            _style = _line_style(_src)
+            _style = line_style(_src)
             # Wind direction is circular: draw as markers (no lines) so the
             # 0<->360 wraparound doesn't create spurious vertical segments.
             if _p == "DD_10M" and _src != OBS_LABEL:
                 _style = {**_style, "linestyle": "none", "marker": ".", "markersize": 5}
             _lead = (_g["valid_time"] - init_time).dt.total_seconds() / 3600.0
             _ax.plot(_lead, _g["value"], label=_src, **_style)
-        _ax.set_ylabel(_UNITS.get(_p, _p), fontsize=_FS_title)
-        _ax.tick_params(labelsize=_FS_axes)
-        _ax.text(0.01, 0.97, _p, transform=_ax.transAxes,
-                 ha="left", va="top", fontsize=_FS_axes)
+        _ax.set_ylabel(_UNITS.get(_p, _p), fontsize=FS_TITLE)
+        _ax.tick_params(labelsize=FS_AXES)
+        _ax.text(0.01, 0.97, param_label(_p), transform=_ax.transAxes,
+                 ha="left", va="top", fontsize=FS_AXES)
         if _p == "DD_10M":
             _ax.set_ylim(0, 360)
             _ax.set_yticks([0, 90, 180, 270, 360])
@@ -225,12 +212,12 @@ def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_ord
         _ax.grid(True, axis="x", which="major", color="0.6", linewidth=0.8, linestyle="--")
         _ax.grid(True, axis="x", which="minor", color="0.8", linewidth=0.6, linestyle=":")
 
-    _axes[-1].set_xlabel("Lead time (h)", fontsize=_FS_axes)
+    _axes[-1].set_xlabel("Lead time (h)", fontsize=FS_AXES)
     _axes[0].set_xlim(left=0)
     _handles, _labels = _axes[0].get_legend_handles_labels()
     _fig.legend(_handles, _labels, loc="lower center", ncol=len(source_order),
-                fontsize=_FS_title, frameon=False, bbox_to_anchor=(0.5, 0.0))
-    _fig.suptitle(f"{station} — Init time {init_time:%Y-%m-%d %H:%M}", fontsize=_FS_title)
+                fontsize=FS_TITLE, frameon=False, bbox_to_anchor=(0.5, 0.0))
+    _fig.suptitle(f"{station} — Init time {init_time:%Y-%m-%d %H:%M}", fontsize=FS_TITLE)
     _fig.tight_layout(rect=[0, 0.05, 1, 0.99])
 
     _out = Path(output_dir)

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -57,7 +57,7 @@ def _(mo, sys):
         forecast = _cli.get("forecast", default=_FORECAST_DEFAULT)
         forecast_steps = _cli.get("forecast_steps", default="0/120/1")
         forecast_label = _cli.get("forecast_label", default="Varda-Single")
-        baselines_raw = _cli.get("baselines", default=_BASELINES_DEFAULT)
+        baselines_raw = _cli.get("baseline", default=_BASELINES_DEFAULT)
         peakweather = _cli.get("peakweather", default=_PW_DEFAULT)
         date = _cli.get("date", default="202504010000")
         station = _cli.get("station", default="KLO")
@@ -172,14 +172,15 @@ def _(
 @app.cell
 def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_order, station):
     import matplotlib.pyplot as plt
+    import matplotlib.ticker as mticker
 
     _UNITS = {"T_2M": "K", "TOT_PREC": "mm", "SP_10M": "m/s", "DD_10M": "deg"}
-    _FS_axes = 8
-    _FS_title = 12
+    _FS_axes = 13
+    _FS_title = 16
 
     def _line_style(src):
         if src == OBS_LABEL:
-            return dict(color="black", linestyle="none", marker="o", markersize=3)
+            return dict(color="red", linestyle="none", marker="o", markersize=3)
         color = (
             "royalblue" if "CH1" in src else
             "seagreen" if "CH2" in src else
@@ -204,17 +205,32 @@ def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_ord
             _g = _sub[_sub["source"] == _src].sort_values("valid_time")
             if _g.empty:
                 continue
-            _ax.plot(_g["valid_time"], _g["value"], label=_src, **_line_style(_src))
+            _style = _line_style(_src)
+            # Wind direction is circular: draw as markers (no lines) so the
+            # 0<->360 wraparound doesn't create spurious vertical segments.
+            if _p == "DD_10M" and _src != OBS_LABEL:
+                _style = {**_style, "linestyle": "none", "marker": ".", "markersize": 5}
+            _lead = (_g["valid_time"] - init_time).dt.total_seconds() / 3600.0
+            _ax.plot(_lead, _g["value"], label=_src, **_style)
         _ax.set_ylabel(_UNITS.get(_p, _p), fontsize=_FS_title)
         _ax.tick_params(labelsize=_FS_axes)
         _ax.text(0.01, 0.97, _p, transform=_ax.transAxes,
                  ha="left", va="top", fontsize=_FS_axes)
+        if _p == "DD_10M":
+            _ax.set_ylim(0, 360)
+            _ax.set_yticks([0, 90, 180, 270, 360])
+        # Lead-time x-axis (hours since init): major every 24 h, minor every 6 h
+        _ax.xaxis.set_major_locator(mticker.MultipleLocator(24))
+        _ax.xaxis.set_minor_locator(mticker.MultipleLocator(6))
+        _ax.grid(True, axis="x", which="major", color="0.6", linewidth=0.8, linestyle="--")
+        _ax.grid(True, axis="x", which="minor", color="0.8", linewidth=0.6, linestyle=":")
 
-    _axes[-1].set_xlabel("Valid time", fontsize=_FS_axes)
+    _axes[-1].set_xlabel("Lead time (h)", fontsize=_FS_axes)
+    _axes[0].set_xlim(left=0)
     _handles, _labels = _axes[0].get_legend_handles_labels()
     _fig.legend(_handles, _labels, loc="lower center", ncol=len(source_order),
                 fontsize=_FS_title, frameon=False, bbox_to_anchor=(0.5, 0.0))
-    _fig.suptitle(f"{station} — init {init_time:%Y-%m-%d %H:%M}", fontsize=_FS_title)
+    _fig.suptitle(f"{station} — Init time {init_time:%Y-%m-%d %H:%M}", fontsize=_FS_title)
     _fig.tight_layout(rect=[0, 0.05, 1, 0.99])
 
     _out = Path(output_dir)

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -84,9 +84,7 @@ def _(baselines_raw, params_raw):
         out = []
         for spec in [s for s in raw.split(";") if s.strip()]:
             root, steps, member, label = spec.split("|")
-            out.append(
-                {"root": root, "steps": steps, "member": member, "label": label}
-            )
+            out.append({"root": root, "steps": steps, "member": member, "label": label})
         return out
 
     baselines = _parse_baselines(baselines_raw)
@@ -170,16 +168,29 @@ def _(
 
 
 @app.cell
-def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_order, station):
+def _(
+    OBS_LABEL,
+    Path,
+    df,
+    display_params,
+    init_time,
+    mo,
+    output_dir,
+    source_order,
+    station,
+):
     import matplotlib.pyplot as plt
     import matplotlib.ticker as mticker
 
-    from publication_style import line_style, param_label, FS_AXES, FS_TITLE
+    from publication_style import line_style, param_label
+
+    plt.style.use(Path(__file__).resolve().parent / "publication.mplstyle")
 
     _UNITS = {"T_2M": "K", "TOT_PREC": "mm", "SP_10M": "m/s", "DD_10M": "deg"}
 
     _fig, _axes = plt.subplots(
-        len(display_params), 1,
+        len(display_params),
+        1,
         figsize=(8, 2.6 * len(display_params)),
         sharex=True,
     )
@@ -199,25 +210,34 @@ def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_ord
                 _style = {**_style, "linestyle": "none", "marker": ".", "markersize": 5}
             _lead = (_g["valid_time"] - init_time).dt.total_seconds() / 3600.0
             _ax.plot(_lead, _g["value"], label=_src, **_style)
-        _ax.set_ylabel(_UNITS.get(_p, _p), fontsize=FS_TITLE)
-        _ax.tick_params(labelsize=FS_AXES)
-        _ax.text(0.01, 0.97, param_label(_p), transform=_ax.transAxes,
-                 ha="left", va="top", fontsize=FS_AXES)
+        _ax.set_ylabel(_UNITS.get(_p, _p))
+        _ax.text(
+            0.01, 0.97, param_label(_p), transform=_ax.transAxes, ha="left", va="top"
+        )
         if _p == "DD_10M":
             _ax.set_ylim(0, 360)
             _ax.set_yticks([0, 90, 180, 270, 360])
         # Lead-time x-axis (hours since init): major every 24 h, minor every 6 h
         _ax.xaxis.set_major_locator(mticker.MultipleLocator(24))
         _ax.xaxis.set_minor_locator(mticker.MultipleLocator(6))
-        _ax.grid(True, axis="x", which="major", color="0.6", linewidth=0.8, linestyle="--")
-        _ax.grid(True, axis="x", which="minor", color="0.8", linewidth=0.6, linestyle=":")
+        _ax.grid(
+            True, axis="x", which="major", color="0.6", linewidth=0.8, linestyle="--"
+        )
+        _ax.grid(
+            True, axis="x", which="minor", color="0.8", linewidth=0.6, linestyle=":"
+        )
 
-    _axes[-1].set_xlabel("Lead time (h)", fontsize=FS_AXES)
+    _axes[-1].set_xlabel("Lead time (h)")
     _axes[0].set_xlim(left=0)
     _handles, _labels = _axes[0].get_legend_handles_labels()
-    _fig.legend(_handles, _labels, loc="lower center", ncol=len(source_order),
-                fontsize=FS_TITLE, frameon=False, bbox_to_anchor=(0.5, 0.0))
-    _fig.suptitle(f"{station} — Init time {init_time:%Y-%m-%d %H:%M}", fontsize=FS_TITLE)
+    _fig.legend(
+        _handles,
+        _labels,
+        loc="lower center",
+        ncol=len(source_order),
+        bbox_to_anchor=(0.5, 0.0),
+    )
+    _fig.suptitle(f"{station} — Init time {init_time:%Y-%m-%d %H:%M}")
     _fig.tight_layout(rect=[0, 0.05, 1, 0.99])
 
     _out = Path(output_dir)
@@ -227,9 +247,9 @@ def _(OBS_LABEL, Path, df, display_params, init_time, mo, output_dir, source_ord
     _fig.savefig(_fname.with_suffix(".png"), dpi=200, bbox_inches="tight")
     plt.close(_fig)
     (_out / "publication_meteogram.html").write_text(
-        '<!doctype html><html><body>'
+        "<!doctype html><html><body>"
         '<img src="publication_meteogram.png" style="max-width:100%">'
-        '</body></html>'
+        "</body></html>"
     )
 
     mo.image(str(_fname.with_suffix(".png")))

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -138,7 +138,10 @@ def _(
         _abs(peakweather), init_time, obs_steps, base_params
     )
     obs_station = add_derived(obs.sel(values=[station]), display_params)
-    station_target = obs.sel(values=[station])[[]]  # coords (lat/lon) only
+    # Mapping target: keep lat/lon coords, drop only the data variables
+    # (obs[[]] would also strip the non-dimension lat/lon coords).
+    _sel = obs.sel(values=[station])
+    station_target = _sel.drop_vars(list(_sel.data_vars))
 
     frames = [station_timeseries_to_long(obs_station, OBS_LABEL, display_params)]
 

--- a/workflow/scripts/publication_style.py
+++ b/workflow/scripts/publication_style.py
@@ -1,0 +1,59 @@
+"""Shared visual style for the publication figures.
+
+Single source of truth for colors, markers, line styles, font sizes, and the
+human-readable parameter labels used by both ``publication_figures.py``
+(lead-time figure) and ``publication_meteogram.py``. Tweak the look of the
+paper figures here.
+"""
+
+# Font sizes (points)
+FS_AXES = 13   # tick labels, axis labels, in-panel annotations
+FS_TITLE = 16  # panel titles, y-axis labels, legend, suptitle
+
+# Label used for the station-observations source (overlaid in the meteogram).
+OBS_LABEL = "Observations"
+
+# Source colors
+COLOR_OBS = "#4ecb8d"
+COLOR_CH1 = "#008dff"
+COLOR_CH2 = "#003a7d"
+COLOR_VARDA = "#d83034"
+
+# Human-readable variable names (used for panel titles / labels).
+PARAM_LABELS = {
+    "T_2M": "2m temperature",
+    "TD_2M": "2m dew point temperature",
+    "TOT_PREC": "total precipitation",
+    "SP_10M": "wind speed",
+    "DD_10M": "wind direction",
+    "U_10M": "10m u-component of wind",
+    "V_10M": "10m v-component of wind",
+}
+
+
+def param_label(param: str) -> str:
+    """Full variable name for a parameter code (falls back to the code)."""
+    return PARAM_LABELS.get(param, param)
+
+
+def line_style(src: str) -> dict:
+    """Return matplotlib plot kwargs (color/marker/line) for a source label.
+
+    Change colors, markers, and line styles for every figure here.
+    """
+    if src == OBS_LABEL:
+        return dict(
+            color=COLOR_OBS,
+            linestyle="none",
+            marker="o",
+            markersize=3.5,
+        )
+    color = (
+        COLOR_CH1 if "CH1" in src else
+        COLOR_CH2 if "CH2" in src else
+        COLOR_VARDA if "Varda" in src else
+        "gray"
+    )
+    linestyle = "--" if "EPS mean" in src else "-"
+    linewidth = 2.25 if "Varda" in src else 1.5
+    return dict(color=color, linestyle=linestyle, linewidth=linewidth)

--- a/workflow/scripts/publication_style.py
+++ b/workflow/scripts/publication_style.py
@@ -1,14 +1,14 @@
 """Shared visual style for the publication figures.
 
-Single source of truth for colors, markers, line styles, font sizes, and the
-human-readable parameter labels used by both ``publication_figures.py``
-(lead-time figure) and ``publication_meteogram.py``. Tweak the look of the
-paper figures here.
-"""
+Source of truth for colors, markers, line styles, and human-readable parameter
+labels used by both ``publication_figures.py`` (lead-time figure) and
+``publication_meteogram.py``.  Font sizes and layout defaults live in
+``publication.mplstyle``; apply it with::
 
-# Font sizes (points)
-FS_AXES = 13   # tick labels, axis labels, in-panel annotations
-FS_TITLE = 16  # panel titles, y-axis labels, legend, suptitle
+    plt.style.use(Path(__file__).parent / "publication.mplstyle")
+
+Tweak the look of the paper figures here.
+"""
 
 # Label used for the station-observations source (overlaid in the meteogram).
 OBS_LABEL = "Observations"
@@ -26,8 +26,8 @@ PARAM_LABELS = {
     "TOT_PREC": "total precipitation",
     "SP_10M": "wind speed",
     "DD_10M": "wind direction",
-    "U_10M": "10m u-component of wind",
-    "V_10M": "10m v-component of wind",
+    "U_10M": "u-component of wind",
+    "V_10M": "v-component of wind",
 }
 
 
@@ -49,10 +49,13 @@ def line_style(src: str) -> dict:
             markersize=3.5,
         )
     color = (
-        COLOR_CH1 if "CH1" in src else
-        COLOR_CH2 if "CH2" in src else
-        COLOR_VARDA if "Varda" in src else
-        "gray"
+        COLOR_CH1
+        if "CH1" in src
+        else COLOR_CH2
+        if "CH2" in src
+        else COLOR_VARDA
+        if "Varda" in src
+        else "gray"
     )
     linestyle = "--" if "EPS mean" in src else "-"
     linewidth = 2.25 if "Varda" in src else 1.5

--- a/workflow/scripts/publication_style.py
+++ b/workflow/scripts/publication_style.py
@@ -21,13 +21,13 @@ COLOR_VARDA = "#d83034"
 
 # Human-readable variable names (used for panel titles / labels).
 PARAM_LABELS = {
-    "T_2M": "2m temperature",
-    "TD_2M": "2m dew point temperature",
-    "TOT_PREC": "total precipitation",
-    "SP_10M": "wind speed",
-    "DD_10M": "wind direction",
-    "U_10M": "u-component of wind",
-    "V_10M": "v-component of wind",
+    "T_2M": "2m Temperature",
+    "TD_2M": "2m Dew Point Temperature",
+    "TOT_PREC": "Total Precipitation",
+    "SP_10M": "Wind Speed",
+    "DD_10M": "Wind Direction",
+    "U_10M": "Eastward Wind",
+    "V_10M": "Northward Wind",
 }
 
 

--- a/workflow/scripts/report_experiment_dashboard.py
+++ b/workflow/scripts/report_experiment_dashboard.py
@@ -18,6 +18,32 @@ logging.basicConfig(
 )
 
 
+def _check_n_samples_consistency(datasets: list[xr.Dataset], paths: list[Path]) -> None:
+    """Raise ValueError if n_samples differ across loaded verification datasets."""
+    for ds, p in zip(datasets, paths):
+        if "n_samples" not in ds.data_vars:
+            raise ValueError(
+                f"'n_samples' is missing from '{p}'.\n"
+                f"This file was likely produced before n_samples tracking was introduced.\n"
+                f"Fix: delete '{p}' and rerun the pipeline."
+            )
+    counts = {
+        str(p): int(ds["n_samples"].sel(season="all", init_hour=-999).item())
+        for ds, p in zip(datasets, paths)
+    }
+    if len(set(counts.values())) <= 1:
+        return
+    max_n = max(counts.values())
+    summary = "\n".join(f"  {p}: {n}" for p, n in counts.items())
+    to_delete = "\n".join(f"  {p}" for p, n in counts.items() if n < max_n)
+    raise ValueError(
+        f"Inconsistent n_samples across verification files:\n{summary}\n\n"
+        f"All runs must cover the same set of forecast dates for a valid dashboard.\n"
+        f"Fix: delete the following file(s) with fewer samples and rerun the pipeline:\n"
+        f"{to_delete}"
+    )
+
+
 def program_summary_log(args):
     """Log a welcome message with the script and template information."""
     LOG.info("=" * 80)
@@ -35,6 +61,7 @@ def main(args):
 
     # Load, de-duplicate lead_time, and keep best provider per source (same logic as verif_plot_metrics)
     dfs = [xr.open_dataset(f) for f in args.verif_files]
+    _check_n_samples_consistency(dfs, args.verif_files)
     dfs = [_ensure_unique_lead_time(d) for d in dfs]
     dfs = _select_best_sources(dfs)
     ds = xr.concat(dfs, dim="source", join="outer")

--- a/workflow/scripts/report_scorecard.py
+++ b/workflow/scripts/report_scorecard.py
@@ -215,13 +215,32 @@ def _load_relative_diff(cfg: dict) -> xr.Dataset:
         if dim != strat_dim:
             sel_coords[dim] = all_value
 
-    model_ds = (
-        xr.open_dataset(cfg["model"]["path"]).sel(**sel_coords).squeeze(drop=True)
-    )
-    baseline_ds = (
-        xr.open_dataset(cfg["baseline"]["path"])
-        .sel(**{**sel_coords, "source": baseline_source})
-        .squeeze(drop=True)
+    model_ds = xr.open_dataset(cfg["model"]["path"])
+    baseline_ds = xr.open_dataset(cfg["baseline"]["path"])
+
+    for label, ds in [("model", model_ds), ("baseline", baseline_ds)]:
+        if "n_samples" not in ds.data_vars:
+            raise ValueError(
+                f"'n_samples' is missing from the {label} dataset '{cfg[label]['path']}'.\n"
+                f"This file was likely produced before n_samples tracking was introduced.\n"
+                f"Fix: delete '{cfg[label]['path']}' and rerun the pipeline."
+            )
+    model_n = int(model_ds["n_samples"].sel(season="all", init_hour=-999).item())
+    baseline_n = int(baseline_ds["n_samples"].sel(season="all", init_hour=-999).item())
+    if model_n != baseline_n:
+        fewer = (
+            cfg["model"]["path"] if model_n < baseline_n else cfg["baseline"]["path"]
+        )
+        raise ValueError(
+            f"n_samples mismatch: model has {model_n} and baseline has {baseline_n} "
+            f"forecast dates.\n"
+            f"Both runs must cover the same set of dates for a valid scorecard.\n"
+            f"Fix: delete '{fewer}' and rerun the pipeline."
+        )
+
+    model_ds = model_ds.sel(**sel_coords).squeeze(drop=True)
+    baseline_ds = baseline_ds.sel(**{**sel_coords, "source": baseline_source}).squeeze(
+        drop=True
     )
 
     common_vars = [v for v in model_ds.data_vars if v in baseline_ds.data_vars]

--- a/workflow/scripts/verification_metrics.py
+++ b/workflow/scripts/verification_metrics.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--regions",
-        type=lambda x: x.split(","),
+        type=lambda x: [r for r in x.split(",") if r],
         help="Comma-separated list of shapefile paths defining regions for stratification.",
         default="",
     )

--- a/workflow/scripts/verification_metrics.py
+++ b/workflow/scripts/verification_metrics.py
@@ -71,10 +71,21 @@ def main(args: ScriptConfig):
     )
 
     # align forecast and truth data spatially and temporally
+    now = datetime.now()
     fcst = map_forecast_to_truth(fcst, truth)
+    # map_forecast_to_truth uses fancy indexing which collapses the spatial
+    # dimension into one monolithic dask chunk; rechunk by step so that
+    # verify() can parallelise over time steps rather than materialising the
+    # full (regions × steps × values) array at once.
+    fcst = fcst.chunk({"step": 1})
     truth = truth.sel(time=fcst["valid_time"])
+    LOG.info(
+        "Aligned forecast and truth in %s seconds",
+        (datetime.now() - now).total_seconds(),
+    )
 
     # compute metrics and statistics
+    now = datetime.now()
     results = verify(
         fcst,
         truth,
@@ -83,11 +94,20 @@ def main(args: ScriptConfig):
         args.regions,
         threshold_dict=args.threshold_dict,
     )
+    LOG.info(
+        "Computed verification metrics in %s seconds",
+        (datetime.now() - now).total_seconds(),
+    )
 
     # save results to NetCDF
+    now = datetime.now()
     args.output.parent.mkdir(parents=True, exist_ok=True)
     results.earthkit.to_netcdf(args.output)
-    LOG.info("Saved verification results to %s", args.output)
+    LOG.info(
+        "Saved verification results to %s in %s seconds",
+        args.output,
+        (datetime.now() - now).total_seconds(),
+    )
 
     LOG.info("Program completed successfully.")
 

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -601,9 +601,57 @@
           "description": "Whether to generate publication figures.",
           "title": "Enabled",
           "type": "boolean"
+        },
+        "meteogram": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PublicationMeteogramConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Publication meteogram case selection (omit to skip it)."
         }
       },
       "title": "PublicationConfig",
+      "type": "object"
+    },
+    "PublicationMeteogramConfig": {
+      "additionalProperties": false,
+      "description": "Case selection for the publication meteogram figure.",
+      "properties": {
+        "init_time": {
+          "description": "Initialisation time (YYYYMMDDHHMM) of the case to plot.",
+          "title": "Init Time",
+          "type": "string"
+        },
+        "station": {
+          "description": "PeakWeather station ID to plot (e.g. KLO, GVE, LUG).",
+          "title": "Station",
+          "type": "string"
+        },
+        "params": {
+          "default": [
+            "T_2M",
+            "TOT_PREC",
+            "SP_10M",
+            "DD_10M"
+          ],
+          "description": "Display parameters (one panel each); SP_10M/DD_10M are derived.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Params",
+          "type": "array"
+        }
+      },
+      "required": [
+        "init_time",
+        "station"
+      ],
+      "title": "PublicationMeteogramConfig",
       "type": "object"
     },
     "ScorecardConfig": {

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -752,7 +752,7 @@
       "description": "Stratification settings for the analysis.",
       "properties": {
         "regions": {
-          "description": "List of region names for stratification.",
+          "description": "List of region names for stratification. Empty list means no spatial stratification.",
           "items": {
             "type": "string"
           },
@@ -760,15 +760,19 @@
           "type": "array"
         },
         "root": {
-          "description": "Root directory where the region shapefiles are stored.",
-          "title": "Root",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Root directory where the region shapefiles are stored. Required when regions is non-empty.",
+          "title": "Root"
         }
       },
-      "required": [
-        "regions",
-        "root"
-      ],
       "title": "Stratification",
       "type": "object"
     },


### PR DESCRIPTION
AI-assisted implementation!

This PR adds meteograms for publication, centralises some ploting style things, uses long names for variables and tries out some colors :) 

Any feedback and changes welcome!

To run only plotting: 
```
evalml publication config/Varda-Single_paper.yaml -- \
  --allowed-rules publication_all publication_meteogram publication_figures \
                  data_download_eckit_geo_grids \
  --forcerun publication_meteogram publication_figures
``` 

Current version of the plots:

<img width="2957" height="1685" alt="image" src="https://github.com/user-attachments/assets/218f849e-4bd3-41d2-b19d-124dfe156e50" />
<img width="2335" height="2056" alt="image" src="https://github.com/user-attachments/assets/25d1d544-996a-4adf-869c-54ae054cfcf8" />




