### PR TITLE
Add forecaster support overlay to meteograms

### DIFF
--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -246,6 +246,10 @@ class MeteogramConfig(BaseModel):
         default=["GVE", "KLO", "LUG"],
         description="List of PeakWeather station IDs to generate meteograms for.",
     )
+    forecaster_support: bool = Field(
+        default=False,
+        description="Whether to overlay the forecaster support points as dots.",
+    )
 
 
 class AnimationsConfig(BaseModel):

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -52,8 +52,7 @@ rule plot_meteogram:
         forecaster_support=lambda wc: (
             str(
                 (
-                    Path(OUT_ROOT)
-                    / f"data/runs/{wc.run_id}/{wc.init_time}/forecaster"
+                    Path(OUT_ROOT) / f"data/runs/{wc.run_id}/{wc.init_time}/forecaster"
                 ).resolve()
             )
             if config["showcase"]["meteograms"].get("forecaster_support", False)

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -49,6 +49,21 @@ rule plot_meteogram:
         ).resolve(),
         fcst_steps=lambda wc: RUN_CONFIGS[wc.run_id]["steps"],
         fcst_label=lambda wc: RUN_CONFIGS[wc.run_id]["label"],
+        forecaster_support=lambda wc: (
+            str(
+                (
+                    Path(OUT_ROOT)
+                    / f"data/runs/{wc.run_id}/{wc.init_time}/forecaster"
+                ).resolve()
+            )
+            if config["showcase"]["meteograms"].get("forecaster_support", False)
+            and RUN_CONFIGS[wc.run_id].get("forecaster")
+            else ""
+        ),
+        forecaster_support_label=lambda wc: (
+            (RUN_CONFIGS[wc.run_id].get("forecaster") or {}).get("label")
+            or "forecaster support"
+        ),
         baseline_roots=lambda wc: [x["root"] for x in _get_available_baselines(wc)],
         baseline_steps=lambda wc: [x["steps"] for x in _get_available_baselines(wc)],
         baseline_labels=lambda wc: [x["label"] for x in _get_available_baselines(wc)],
@@ -85,6 +100,12 @@ rule plot_meteogram:
             CMD_ARGS+=(--baseline_steps "${{BASELINE_STEPS[$i]}}")
             CMD_ARGS+=(--baseline_label "${{BASELINE_LABELS[$i]}}")
         done
+
+        FORECASTER_SUPPORT={params.forecaster_support:q}
+        if [ -n "$FORECASTER_SUPPORT" ]; then
+            CMD_ARGS+=(--forecaster_support "$FORECASTER_SUPPORT")
+            CMD_ARGS+=(--forecaster_support_label {params.forecaster_support_label:q})
+        fi
 
         python {input.script} "${{CMD_ARGS[@]}}" >{log} 2>&1
         """

--- a/workflow/scripts/plot_meteogram.py
+++ b/workflow/scripts/plot_meteogram.py
@@ -88,6 +88,18 @@ def main():
         help="Label for each baseline line in plot legend (repeatable).",
     )
     parser.add_argument(
+        "--forecaster_support",
+        type=str,
+        default=None,
+        help="Directory to forecaster grib data, shown as dots.",
+    )
+    parser.add_argument(
+        "--forecaster_support_label",
+        type=str,
+        default="forecaster support",
+        help="Label for the forecaster support dots in plot legend.",
+    )
+    parser.add_argument(
         "--analysis", type=str, default=None, help="Path to analysis data root"
     )
     parser.add_argument(
@@ -164,6 +176,16 @@ def main():
             preprocess_ds(load_forecast_data(root, init_time, step, paramlist), param)
         )
 
+    forecaster_support_ds = None
+    if args.forecaster_support:
+        LOG.info("Loading forecaster support from %s", args.forecaster_support)
+        forecaster_support_ds = preprocess_ds(
+            load_forecast_data(
+                Path(args.forecaster_support), init_time, None, paramlist
+            ),
+            param,
+        )
+
     # Load station metadata once
     LOG.info("Loading station metadata from %s", peakweather_dir)
     peakweather = PeakWeatherDataset(root=peakweather_dir)
@@ -192,6 +214,11 @@ def main():
         baseline_station_ds_list = [
             map_forecast_to_truth(ds, station_ds) for ds in baseline_ds_list
         ]
+        forecaster_support_station_ds = (
+            map_forecast_to_truth(forecaster_support_ds, station_ds)
+            if forecaster_support_ds is not None
+            else None
+        )
 
         fig, ax = plt.subplots()
 
@@ -217,6 +244,15 @@ def main():
             color="C0",
             label=forecast_label,
         )
+        if forecaster_support_station_ds is not None:
+            ax.plot(
+                forecaster_support_station_ds["valid_time"].values,
+                forecaster_support_station_ds[param].values,
+                color="C0",
+                ls="none",
+                marker="o",
+                label=args.forecaster_support_label,
+            )
 
         ax.legend()
         ax.set_ylabel(f"{short} ({units})" if short or units else "")

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -551,6 +551,12 @@
           },
           "title": "Stations",
           "type": "array"
+        },
+        "forecaster_support": {
+          "default": false,
+          "description": "Whether to overlay the forecaster support points as dots.",
+          "title": "Forecaster Support",
+          "type": "boolean"
         }
       },
       "title": "MeteogramConfig",


### PR DESCRIPTION
Adds an option to show the forecaster support points as dots on the meteograms.

Off by default, turn it on with:

```yaml
meteograms:
  forecaster_support: true
```

Only runs that have a forecaster are affected; the rest ignore the flag.

**Legend label:** the dots are labelled `forecaster support` by default, or with whatever `label` is set on the run's forecaster, if present.

<img width="640" height="480" alt="Forecaster_Support_Demo_202506271800_U_10M_SIO" src="https://github.com/user-attachments/assets/c02e55c3-18b7-4584-8488-6c4df959c4b9" />

