### PR TITLE
Safeguard against differing numbers of initialization in experiment reports and scorecards

### DIFF
--- a/workflow/scripts/report_experiment_dashboard.py
+++ b/workflow/scripts/report_experiment_dashboard.py
@@ -18,6 +18,32 @@ logging.basicConfig(
 )
 
 
+def _check_n_samples_consistency(datasets: list[xr.Dataset], paths: list[Path]) -> None:
+    """Raise ValueError if n_samples differ across loaded verification datasets."""
+    for ds, p in zip(datasets, paths):
+        if "n_samples" not in ds.data_vars:
+            raise ValueError(
+                f"'n_samples' is missing from '{p}'.\n"
+                f"This file was likely produced before n_samples tracking was introduced.\n"
+                f"Fix: delete '{p}' and rerun the pipeline."
+            )
+    counts = {
+        str(p): int(ds["n_samples"].sel(season="all", init_hour=-999).item())
+        for ds, p in zip(datasets, paths)
+    }
+    if len(set(counts.values())) <= 1:
+        return
+    max_n = max(counts.values())
+    summary = "\n".join(f"  {p}: {n}" for p, n in counts.items())
+    to_delete = "\n".join(f"  {p}" for p, n in counts.items() if n < max_n)
+    raise ValueError(
+        f"Inconsistent n_samples across verification files:\n{summary}\n\n"
+        f"All runs must cover the same set of forecast dates for a valid dashboard.\n"
+        f"Fix: delete the following file(s) with fewer samples and rerun the pipeline:\n"
+        f"{to_delete}"
+    )
+
+
 def program_summary_log(args):
     """Log a welcome message with the script and template information."""
     LOG.info("=" * 80)
@@ -35,6 +61,7 @@ def main(args):
 
     # Load, de-duplicate lead_time, and keep best provider per source (same logic as verif_plot_metrics)
     dfs = [xr.open_dataset(f) for f in args.verif_files]
+    _check_n_samples_consistency(dfs, args.verif_files)
     dfs = [_ensure_unique_lead_time(d) for d in dfs]
     dfs = _select_best_sources(dfs)
     ds = xr.concat(dfs, dim="source", join="outer")

--- a/workflow/scripts/report_scorecard.py
+++ b/workflow/scripts/report_scorecard.py
@@ -215,13 +215,32 @@ def _load_relative_diff(cfg: dict) -> xr.Dataset:
         if dim != strat_dim:
             sel_coords[dim] = all_value
 
-    model_ds = (
-        xr.open_dataset(cfg["model"]["path"]).sel(**sel_coords).squeeze(drop=True)
-    )
-    baseline_ds = (
-        xr.open_dataset(cfg["baseline"]["path"])
-        .sel(**{**sel_coords, "source": baseline_source})
-        .squeeze(drop=True)
+    model_ds = xr.open_dataset(cfg["model"]["path"])
+    baseline_ds = xr.open_dataset(cfg["baseline"]["path"])
+
+    for label, ds in [("model", model_ds), ("baseline", baseline_ds)]:
+        if "n_samples" not in ds.data_vars:
+            raise ValueError(
+                f"'n_samples' is missing from the {label} dataset '{cfg[label]['path']}'.\n"
+                f"This file was likely produced before n_samples tracking was introduced.\n"
+                f"Fix: delete '{cfg[label]['path']}' and rerun the pipeline."
+            )
+    model_n = int(model_ds["n_samples"].sel(season="all", init_hour=-999).item())
+    baseline_n = int(baseline_ds["n_samples"].sel(season="all", init_hour=-999).item())
+    if model_n != baseline_n:
+        fewer = (
+            cfg["model"]["path"] if model_n < baseline_n else cfg["baseline"]["path"]
+        )
+        raise ValueError(
+            f"n_samples mismatch: model has {model_n} and baseline has {baseline_n} "
+            f"forecast dates.\n"
+            f"Both runs must cover the same set of dates for a valid scorecard.\n"
+            f"Fix: delete '{fewer}' and rerun the pipeline."
+        )
+
+    model_ds = model_ds.sel(**sel_coords).squeeze(drop=True)
+    baseline_ds = baseline_ds.sel(**{**sel_coords, "source": baseline_source}).squeeze(
+        drop=True
     )
 
     common_vars = [v for v in model_ds.data_vars if v in baseline_ds.data_vars]


### PR DESCRIPTION
When evalml is often rerun on big experiments and with e.g. `--rerun-triggers mtime` flags or similar, we have no guarantee that the same initializations are being used in each of the contributing forecast sources. Therefore this PR implements a simple check for that.

### Summary of changes
* check number of samples (initializations) used in aggregated verification results and abort if not identical

### Example log messages

from report_scorecards rule:
```
ValueError: n_samples mismatch: model has 14 and baseline has 120 forecast dates.
Both runs must cover the same set of dates for a valid scorecard.
Fix: delete 'output/data/runs/temporal_downscaler-f927-1ee3-on-forecaster-c304-23e7/495c/verif_aggregated_2b83.nc' and rerun the pipeline.
```

from report_experiment_dashboard rule:
```
ValueError: Inconsistent n_samples across verification files:
  output/data/baselines/baseline-7e02/verif_aggregated_2b83.nc: 120
  output/data/baselines/baseline-ce47/verif_aggregated_2b83.nc: 120
  output/data/baselines/baseline-7342/verif_aggregated_2b83.nc: 120
  output/data/baselines/baseline-e0f0/verif_aggregated_2b83.nc: 120
  output/data/runs/temporal_downscaler-f927-1ee3-on-forecaster-c304-23e7/495c/verif_aggregated_2b83.nc: 14

All runs must cover the same set of forecast dates for a valid dashboard.
Fix: delete the following file(s) with fewer samples and rerun the pipeline:
  output/data/runs/temporal_downscaler-f927-1ee3-on-forecaster-c304-23e7/495c/verif_aggregated_2b83.nc
```
