### PR TITLE
Remove labels from intermediate verification results

### DIFF
--- a/config/forecasters-ich1-oper-fixed.yaml
+++ b/config/forecasters-ich1-oper-fixed.yaml
@@ -18,8 +18,7 @@ runs:
       steps: 0/120/6
       config: resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper.yaml
       extra_requirements:
-        - git+https://github.com/ecmwf/anemoi-inference.git@de4cc0decd47dd593d2bb04cf9247e57a216d3cd
-
+        - anemoi-inference==0.11.1
   # - forecaster:
   #     checkpoint: https://service.meteoswiss.ch/mlstore#/experiments/602/runs/233b1274e79b4bfea98378d196a8aba0
   #     label: stage_C_realch1

--- a/config/forecasters-ich1-oper.yaml
+++ b/config/forecasters-ich1-oper.yaml
@@ -20,7 +20,7 @@ runs:
       extra_requirements:
         - earthkit-utils<0.2.0
         - earthkit-data<0.19.0
-        - git+https://github.com/ecmwf/anemoi-inference.git@de4cc0decd47dd593d2bb04cf9247e57a216d3cd
+        - anemoi-inference==0.11.1
 
   - baseline:
       label: ICON-CH1-ctrl

--- a/config/forecasters-ich1.yaml
+++ b/config/forecasters-ich1.yaml
@@ -16,7 +16,7 @@ runs:
       extra_requirements:
         - earthkit-utils<0.2.0
         - earthkit-data<0.19.0
-        - git+https://github.com/ecmwf/anemoi-inference.git@de4cc0decd47dd593d2bb04cf9247e57a216d3cd
+        - anemoi-inference==0.11.1
 
   - forecaster:
       checkpoint: /scratch/mch/apennino/output/checkpoint/973b78b8b39543949abc2b154c5f98d9/inference-last.ckpt
@@ -26,7 +26,7 @@ runs:
       extra_requirements:
         - earthkit-utils<0.2.0
         - earthkit-data<0.19.0
-        - git+https://github.com/ecmwf/anemoi-inference.git@de4cc0decd47dd593d2bb04cf9247e57a216d3cd
+        - anemoi-inference==0.11.1
 
   # - forecaster:
   #     checkpoint: https://huggingface.co/met-no/bris_cloudy-skies/blob/main/2025-10/cloudy-skies-2025-10.ckpt

--- a/resources/report/dashboard/script.js
+++ b/resources/report/dashboard/script.js
@@ -139,34 +139,47 @@ let legendView = null;
 
 async function renderLegend(filteredData) {
   const src = filteredData.length ? filteredData : DATA;
+  const tinyMark = { type: "point", filled: true, opacity: 0, size: 0 };
   const spec = {
-    data: { values: src },
-    config: { view: { stroke: null } },
-    mark: { type: "point", filled: true, opacity: 0, size: 0 },
-    width: 1,
-    height: 1,
-    encoding: {
-      color: {
-        field: "source",
-        type: "nominal",
-        scale: { domain: ALL_SOURCES },
-        legend: {
-          orient: "left", title: "Source", offset: 8,
-          symbolType: "circle", symbolSize: 120,
+    config: { view: { stroke: null }, concat: { spacing: 32 } },
+    hconcat: [
+      {
+        data: { values: src },
+        mark: tinyMark,
+        width: 1, height: 1,
+        encoding: {
+          shape: {
+            field: "region_season_init",
+            type: "nominal",
+            legend: {
+              orient: "bottom",
+              direction: "horizontal",
+              title: "Region / Season / Init",
+              labelLimit: 400,
+              symbolType: "circle", symbolSize: 120,
+            },
+          },
         },
       },
-      shape: {
-        field: "region_season_init",
-        type: "nominal",
-        legend: {
-          orient: "right",
-          title: "Region / Season / Init",
-          offset: 8,
-          labelLimit: 400,
-          symbolType: "circle", symbolSize: 120,
+      {
+        data: { values: src },
+        mark: tinyMark,
+        width: 1, height: 1,
+        encoding: {
+          color: {
+            field: "source",
+            type: "nominal",
+            scale: { domain: ALL_SOURCES },
+            legend: {
+              orient: "bottom",
+              direction: "horizontal",
+              title: "Source",
+              symbolType: "circle", symbolSize: 120,
+            },
+          },
         },
       },
-    },
+    ],
   };
   try {
     if (legendView) { try { legendView.finalize(); } catch (e) {} }

--- a/resources/report/dashboard/template.html.jinja2
+++ b/resources/report/dashboard/template.html.jinja2
@@ -35,9 +35,12 @@
         .controls-summary { font-size: 0.8rem; color: #555; display: none; }
         .controls { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1rem; }
         .controls.collapsed { display: none; }
-        .control-group { flex: 1 1 220px; min-width: 180px; }
-        .choices__inner { min-height: 80px; }
-        label { font-weight: bold; display: block; }
+        .control-group { flex: 1 1 220px; min-width: 180px; display: flex; flex-direction: column; }
+        .choices { flex: 1; display: flex; flex-direction: column; }
+        .choices__inner { flex: 1; min-height: unset; height: 80px; overflow-y: auto; border-right: 1px solid #b0b0b0 !important; }
+        label { font-weight: bold; display: block; font-size: 0.75rem; }
+        .choices__item { font-size: 0.72rem !important; padding: 2px 6px !important; }
+        .choices__list--dropdown .choices__item { font-size: 0.72rem !important; }
 
         /* Legend sits above the table */
         #legend-chart { margin-bottom: 4px; }
@@ -113,6 +116,9 @@
 </div>
 
 <div id="tab_scores" class="tab-content active">
+    {% if header_text %}
+    <p style="margin: 0 0 1rem; color: #555; font-size: 0.9rem;">{{ header_text | e }}</p>
+    {% endif %}
     <div class="controls-header">
         <button class="controls-toggle" id="controls-toggle">▲ Hide filters</button>
         <span class="controls-summary" id="controls-summary"></span>

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -50,7 +50,7 @@ rule report_experiment_dashboard:
             )
             for sid in EXPERIMENT_PARTICIPANTS
         )
-        + ",truth_{}:{}".format(TRUTH_HASH, config["truth"]["label"]),
+        + ",truth-{}:{}".format(TRUTH_HASH, config["truth"]["label"]),
     shell:
         """
         python {input.script} \

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -39,6 +39,18 @@ rule report_experiment_dashboard:
         sources=",".join(list(EXPERIMENT_PARTICIPANTS.keys())),
         header_text=make_header_text(),
         stratification=" ".join(config["experiment"]["dashboard"]["stratification"]),
+        label_map=",".join(
+            "{}:{}".format(
+                sid,
+                (
+                    BASELINE_CONFIGS[sid].get("label", sid)
+                    if sid in BASELINE_CONFIGS
+                    else RUN_CONFIGS[sid].get("label", sid)
+                ),
+            )
+            for sid in EXPERIMENT_PARTICIPANTS
+        )
+        + ",truth_{}:{}".format(TRUTH_HASH, config["truth"]["label"]),
     shell:
         """
         python {input.script} \
@@ -48,6 +60,7 @@ rule report_experiment_dashboard:
             --header_text "{params.header_text}" \
             --configfile "{input.configfile}" \
             --stratification {params.stratification} \
+            --labels "{params.label_map}" \
             --output {output} >{log} 2>&1
         """
 
@@ -76,10 +89,14 @@ rule report_scorecard:
         lead_times=lambda wc: SCORECARD_CONFIGS[wc.scorecard_name]["lead_times"],
         stratification=lambda wc: SCORECARD_CONFIGS[wc.scorecard_name]["stratification"],
         variables=lambda wc: SCORECARD_CONFIGS[wc.scorecard_name]["variables"],
-        run_source=lambda wc: RUN_CONFIGS[f"{wc.env_id}/{wc.config_hash}"].get(
+        run_source=lambda wc: f"{wc.env_id}/{wc.config_hash}",
+        run_label=lambda wc: RUN_CONFIGS[f"{wc.env_id}/{wc.config_hash}"].get(
             "label", f"{wc.env_id}/{wc.config_hash}"
         ),
-        baseline_source=lambda wc: SCORECARD_CONFIGS[wc.scorecard_name]["baseline"],
+        baseline_source=lambda wc: resolve_baseline_id(
+            SCORECARD_CONFIGS[wc.scorecard_name]["baseline"]
+        ),
+        baseline_label=lambda wc: SCORECARD_CONFIGS[wc.scorecard_name]["baseline"],
     shell:
         """
         VAR_ARGS=()
@@ -91,7 +108,9 @@ rule report_scorecard:
             --verif_run {input.verif_run:q} \
             --verif_baseline {input.verif_baseline:q} \
             --run_source {params.run_source:q} \
+            --run_label {params.run_label:q} \
             --baseline_source {params.baseline_source:q} \
+            --baseline_label {params.baseline_label:q} \
             --lead_times {params.lead_times:q} \
             --stratification {params.stratification:q} \
             "${{VAR_ARGS[@]}}" \

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -29,7 +29,7 @@ rule verification_metrics_baseline:
         baseline_steps=lambda wc: BASELINE_CONFIGS[wc.baseline_id]["steps"],
         member=lambda wc: BASELINE_CONFIGS[wc.baseline_id].get("member", "000"),
         truth=config["truth"]["root"],
-        truth_source_id=f"truth_{TRUTH_HASH}",
+        truth_source_id=f"truth-{TRUTH_HASH}",
         regions=REGIONS,
         experiment_params=",".join(EXPERIMENT_PARAMS),
         threshold_dict=config["experiment"]["thresholds"],
@@ -80,7 +80,7 @@ rule verification_metrics:
     params:
         fcst_steps=lambda wc: RUN_CONFIGS[wc.run_id]["steps"],
         truth=config["truth"]["root"],
-        truth_source_id=f"truth_{TRUTH_HASH}",
+        truth_source_id=f"truth-{TRUTH_HASH}",
         regions=REGIONS,
         grib_out_dir=lambda wc: (
             Path(OUT_ROOT) / f"data/runs/{wc.run_id}/{wc.init_time}/grib"
@@ -175,7 +175,7 @@ rule verification_metrics_plot:
             )
             for sid in EXPERIMENT_PARTICIPANTS
         )
-        + ",truth_{}:{}".format(TRUTH_HASH, config["truth"]["label"]),
+        + ",truth-{}:{}".format(TRUTH_HASH, config["truth"]["label"]),
     shell:
         """
         uv run {input.script} {input.verif} --output_dir {output} --labels "{params.label_map}" >{log} 2>&1

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -26,11 +26,10 @@ rule verification_metrics_baseline:
         mem_mb=80_000,
         runtime="120m",
     params:
-        baseline_label=lambda wc: BASELINE_CONFIGS[wc.baseline_id].get("label"),
         baseline_steps=lambda wc: BASELINE_CONFIGS[wc.baseline_id]["steps"],
         member=lambda wc: BASELINE_CONFIGS[wc.baseline_id].get("member", "000"),
         truth=config["truth"]["root"],
-        truth_label=config["truth"]["label"],
+        truth_source_id=f"truth_{TRUTH_HASH}",
         regions=REGIONS,
         experiment_params=",".join(EXPERIMENT_PARAMS),
         threshold_dict=config["experiment"]["thresholds"],
@@ -42,8 +41,8 @@ rule verification_metrics_baseline:
             --truth {params.truth} \
             --reftime {wildcards.init_time} \
             --steps "{params.baseline_steps}" \
-            --label "{params.baseline_label}" \
-            --truth_label "{params.truth_label}" \
+            --source_id "{wildcards.baseline_id}" \
+            --truth_source_id "{params.truth_source_id}" \
             --regions "{params.regions}" \
             --params "{params.experiment_params}" \
             --threshold_dict "{params.threshold_dict}" \
@@ -79,10 +78,9 @@ rule verification_metrics:
     # run_id="^" # to avoid ambiguitiy with run_baseline_verif
     # TODO: implement logic to use experiment name instead of run_id as wildcard
     params:
-        fcst_label=lambda wc: RUN_CONFIGS[wc.run_id].get("label"),
         fcst_steps=lambda wc: RUN_CONFIGS[wc.run_id]["steps"],
         truth=config["truth"]["root"],
-        truth_label=config["truth"]["label"],
+        truth_source_id=f"truth_{TRUTH_HASH}",
         regions=REGIONS,
         grib_out_dir=lambda wc: (
             Path(OUT_ROOT) / f"data/runs/{wc.run_id}/{wc.init_time}/grib"
@@ -97,8 +95,8 @@ rule verification_metrics:
             --truth {params.truth} \
             --reftime {wildcards.init_time} \
             --steps "{params.fcst_steps}" \
-            --label "{params.fcst_label}" \
-            --truth_label "{params.truth_label}" \
+            --source_id "{wildcards.run_id}" \
+            --truth_source_id "{params.truth_source_id}" \
             --regions "{params.regions}" \
             --params "{params.experiment_params}" \
             --threshold_dict "{params.threshold_dict}" \
@@ -166,10 +164,21 @@ rule verification_metrics_plot:
         mem_mb=50_000,
         runtime="20m",
     params:
-        labels=",".join(list(EXPERIMENT_PARTICIPANTS.keys())),
+        label_map=",".join(
+            "{}:{}".format(
+                sid,
+                (
+                    BASELINE_CONFIGS[sid].get("label", sid)
+                    if sid in BASELINE_CONFIGS
+                    else RUN_CONFIGS[sid].get("label", sid)
+                ),
+            )
+            for sid in EXPERIMENT_PARTICIPANTS
+        )
+        + ",truth_{}:{}".format(TRUTH_HASH, config["truth"]["label"]),
     shell:
         """
-        uv run {input.script} {input.verif} --output_dir {output} >{log} 2>&1
+        uv run {input.script} {input.verif} --output_dir {output} --labels "{params.label_map}" >{log} 2>&1
         """
 
 

--- a/workflow/scripts/report_experiment_dashboard.py
+++ b/workflow/scripts/report_experiment_dashboard.py
@@ -78,6 +78,9 @@ def main(args):
     df["init_hour"] = df["init_hour"].astype(str).str.zfill(2) + ":00 UTC"
     df["init_hour"] = df["init_hour"].where(df["init_hour"] != "-999:00 UTC", "all")
 
+    if args.label_map:
+        df["source"] = df["source"].map(lambda s: args.label_map.get(s, s))
+
     # retain only rows relevant for the active stratifications
     stratification = args.stratification
     if "region" not in stratification:
@@ -219,7 +222,18 @@ if __name__ == "__main__":
         default=Path("dashboard.html"),
         help="Path to save the generated HTML dashboard file.",
     )
+    parser.add_argument(
+        "--labels",
+        type=str,
+        default="",
+        help="Comma-separated source_id:display_label pairs for legend text.",
+    )
     args = parser.parse_args()
+    args.label_map = {}
+    for pair in args.labels.split(","):
+        if ":" in pair:
+            sid, _, lbl = pair.partition(":")
+            args.label_map[sid.strip()] = lbl.strip()
 
     main(args)
 

--- a/workflow/scripts/report_scorecard.py
+++ b/workflow/scripts/report_scorecard.py
@@ -182,8 +182,18 @@ def _build_config(args) -> dict:
         }
 
     return {
-        "model": {"path": args.verif_run, "source": args.run_source},
-        "baseline": {"path": args.verif_baseline, "source": args.baseline_source},
+        "model": {
+            "path": args.verif_run,
+            "source": args.run_source,
+            "label": args.run_label if args.run_label is not None else args.run_source,
+        },
+        "baseline": {
+            "path": args.verif_baseline,
+            "source": args.baseline_source,
+            "label": args.baseline_label
+            if args.baseline_label is not None
+            else args.baseline_source,
+        },
         "stratification": args.stratification,
         "lead_times": args.lead_times,
         # All recognised metrics — every entry must also appear in metric_directions.
@@ -605,8 +615,8 @@ def _render_scorecard(diff: xr.Dataset, cfg: dict, outfn: Path):
     legend = plot["legend"]
     dots = plot["dots"]
     fonts = plot["fonts"]
-    model_source = cfg["model"]["source"]
-    baseline_source = cfg["baseline"]["source"]
+    model_source = cfg["model"]["label"]
+    baseline_source = cfg["baseline"]["label"]
     strat_dim = cfg.get("stratification", "region")
 
     plt.rcParams["font.family"] = plot["rcparams"]["font_family"]
@@ -801,6 +811,18 @@ if __name__ == "__main__":
         type=str,
         required=True,
         help="Value of the 'source' dim to select inside --verif_baseline.",
+    )
+    parser.add_argument(
+        "--run_label",
+        type=str,
+        default=None,
+        help="Human-readable label for the model run (used in plot titles/legend). Defaults to --run_source.",
+    )
+    parser.add_argument(
+        "--baseline_label",
+        type=str,
+        default=None,
+        help="Human-readable label for the baseline (used in plot titles/legend). Defaults to --baseline_source.",
     )
     parser.add_argument(
         "--lead_times",

--- a/workflow/scripts/verification_aggregation.py
+++ b/workflow/scripts/verification_aggregation.py
@@ -141,6 +141,15 @@ def main(args: Namespace) -> None:
     # TODO: implement grouping
 
     LOG.info("Reading %d verification files", len(args.verif_files))
+    source_sets = [
+        frozenset(xr.open_dataset(f, engine="netcdf4")["source"].values)
+        for f in args.verif_files
+    ]
+    if len(set(source_sets)) > 1:
+        raise ValueError(
+            f"Inconsistent source values across verif files — a label may have "
+            f"changed between runs without triggering a rerun: {set(source_sets)}"
+        )
     ds = xr.open_mfdataset(
         sorted(args.verif_files),
         combine="nested",

--- a/workflow/scripts/verification_metrics.py
+++ b/workflow/scripts/verification_metrics.py
@@ -78,8 +78,8 @@ def main(args: ScriptConfig):
     results = verify(
         fcst,
         truth,
-        args.label,
-        args.truth_label,
+        args.source_id,
+        args.truth_source_id,
         args.regions,
         threshold_dict=args.threshold_dict,
     )
@@ -126,16 +126,16 @@ if __name__ == "__main__":
         help="Forecast steps in the format 'start/stop/step' (default: 0/120/6).",
     )
     parser.add_argument(
-        "--label",
+        "--source_id",
         type=str,
-        default="COSMO-E",
-        help="Label for the forecast or baseline data (default: COSMO-E).",
+        required=True,
+        help="Stable identifier for the forecast or baseline source (e.g. run_id or baseline_id).",
     )
     parser.add_argument(
-        "--truth_label",
+        "--truth_source_id",
         type=str,
-        default="COSMO KENDA",
-        help="Label for the truth data (default: COSMO KENDA).",
+        required=True,
+        help="Stable identifier for the truth source (e.g. truth_<TRUTH_HASH>).",
     )
     parser.add_argument(
         "--regions",

--- a/workflow/scripts/verification_plot_metrics.py
+++ b/workflow/scripts/verification_plot_metrics.py
@@ -127,6 +127,7 @@ def main(args: Namespace) -> None:
         title = f"{metric} - {param} - {region}"
         title += f"- {season} - {init_hour}" if args.stratify else ""
         for source, df in sub_df.groupby("source"):
+            display_label = args.label_map.get(source, source)
             df.plot(
                 x="step",
                 y="value",
@@ -135,7 +136,7 @@ def main(args: Namespace) -> None:
                 title=title,
                 xlabel="Lead Time [h]",
                 ylabel=decode_metric(metric),
-                label=source,
+                label=display_label,
                 color="black" if "analysis" in source else None,
                 ax=ax,
             )
@@ -168,5 +169,16 @@ if __name__ == "__main__":
         default="plots",
         help="Path to save the aggregated results.",
     )
+    parser.add_argument(
+        "--labels",
+        type=str,
+        default="",
+        help="Comma-separated source_id:display_label pairs for legend text.",
+    )
     args = parser.parse_args()
+    args.label_map = {}
+    for pair in args.labels.split(","):
+        if ":" in pair:
+            sid, _, lbl = pair.partition(":")
+            args.label_map[sid.strip()] = lbl.strip()
     main(args)


### PR DESCRIPTION
If evalml experiments are rerun with changed labels, this causes issues in the aggregated verification results as identification of scores and metrics is by labels (the dimension source in the verif_....nc files). To avoid potential confusion, we need to switch from human-readable labels to hash-based ids as elsewhere in evalml.

### Summary of changes
* Remove labels as source identifiers
* provide id:label key-value arguments to reports scripts for decoding ids