### PR TITLE
Fix meteogram obs for non-default stations and missing time import

### DIFF
--- a/workflow/rules/publication.smk
+++ b/workflow/rules/publication.smk
@@ -161,7 +161,6 @@ rule publication_meteogram:
         baselines=_meteogram_baselines(),
         date=config["publication"]["meteogram"]["init_time"],
         station=config["publication"]["meteogram"]["station"],
-        obs=lambda wc: f"jretrievedwh:locations={config['publication']['meteogram']['station']}",
         params=",".join(config["publication"]["meteogram"]["params"]),
     shell:
         """
@@ -172,7 +171,6 @@ rule publication_meteogram:
             --forecast_steps {params.forecast_steps:q} \
             --forecast_label {params.forecast_label:q} \
             --baseline {params.baselines:q} \
-            --obs {params.obs:q} \
             --date {params.date:q} \
             --station {params.station:q} \
             --params {params.params:q} \

--- a/workflow/scripts/publication_meteogram.py
+++ b/workflow/scripts/publication_meteogram.py
@@ -7,6 +7,7 @@ app = marimo.App(width="full")
 @app.cell
 def _():
     import sys
+    import time
     from pathlib import Path
 
     import marimo as mo
@@ -14,7 +15,7 @@ def _():
     _script_dir = Path(__file__).resolve().parent  # workflow/scripts/
     sys.path.append(str(_script_dir))
     project_root = _script_dir.parent.parent
-    return Path, mo, project_root, sys
+    return Path, mo, project_root, sys, time
 
 
 @app.cell
@@ -38,7 +39,6 @@ def _(mo, sys):
         "/store_new/mch/msopr/osm/ICON-CH1-EPS|0/33/1|mean|ICON-CH1-EPS mean;"
         "/store_new/mch/msopr/osm/ICON-CH2-EPS|0/120/1|mean|ICON-CH2-EPS mean"
     )
-    _OBS_DEFAULT = "jretrievedwh:locations=KLO"
 
     _cli = mo.cli_args()
     if not _cli and len(sys.argv) > 1:
@@ -49,7 +49,6 @@ def _(mo, sys):
         _p.add_argument("--forecast_steps", default="0/120/1")
         _p.add_argument("--forecast_label", default="Varda-Single")
         _p.add_argument("--baseline", action="append", default=None)
-        _p.add_argument("--obs", default=_OBS_DEFAULT)
         _p.add_argument("--date", default="202504010000")
         _p.add_argument("--station", default="KLO")
         _p.add_argument("--params", default="T_2M,TOT_PREC,SP_10M,DD_10M")
@@ -59,7 +58,6 @@ def _(mo, sys):
         forecast_steps = _a.forecast_steps
         forecast_label = _a.forecast_label
         baselines_raw = ";".join(_a.baseline) if _a.baseline else _BASELINES_DEFAULT
-        obs_source = _a.obs
         date = _a.date
         station = _a.station
         params_raw = _a.params
@@ -70,7 +68,6 @@ def _(mo, sys):
         forecast_steps = _cli.get("forecast_steps", default="0/120/1")
         forecast_label = _cli.get("forecast_label", default="Varda-Single")
         baselines_raw = _cli.get("baseline", default=_BASELINES_DEFAULT)
-        obs_source = _cli.get("obs", default=_OBS_DEFAULT)
         date = _cli.get("date", default="202504010000")
         station = _cli.get("station", default="KLO")
         params_raw = _cli.get("params", default="T_2M,TOT_PREC,SP_10M,DD_10M")
@@ -84,7 +81,6 @@ def _(mo, sys):
         forecast_steps,
         output_dir,
         params_raw,
-        obs_source,
         station,
     )
 
@@ -114,9 +110,9 @@ def _(
     forecast,
     forecast_label,
     forecast_steps,
-    obs_source,
     project_root,
     station,
+    time,
 ):
     from datetime import datetime
 
@@ -143,6 +139,8 @@ def _(
     init_time = datetime.strptime(str(date), "%Y%m%d%H%M")
     base_params = expand_to_base_params(display_params)
 
+    # Observations for the plotted station from the MeteoSwiss DWH.
+    obs_source = f"jretrievedwh:locations={station}"
     LOG.info("meteogram: loading observations from %s", obs_source)
     _t0 = time.perf_counter()
     obs_steps = parse_steps(forecast_steps)
@@ -208,6 +206,7 @@ def _(
     output_dir,
     source_order,
     station,
+    time,
 ):
     import matplotlib.pyplot as plt
     import matplotlib.ticker as mticker


### PR DESCRIPTION
AI assisted implementation!

- Derive the jretrievedwh obs marker from --station inside the script instead of passing a separate --obs argument. The marker value contains '=' (e.g. jretrievedwh:locations=KLO), which marimo's cli_args drops, so obs silently fell back to the KLO default and any non-KLO station was broken (also via the snakemake rule). The rule no longer passes --obs.
- Import `time` in the entry cell and thread it through: the timing log lines used time.perf_counter() but `time` was never imported (NameError at runtime).