### PR TITLE
latency wait

### DIFF
--- a/src/evalml/cli.py
+++ b/src/evalml/cli.py
@@ -26,6 +26,12 @@ def _base_snakemake_command(
     command += config.profile.parsable()
     command += ["--configfile", str(configfile)]
     command += ["--cores", str(cores)]
+    # Lustre (and other network filesystems on Balfrin) can have significant
+    # latency between a job writing an output file and it becoming visible to
+    # the Snakemake process on the login node. This flag overwrites the default 
+    # of 5s in an attempt to make the workflow more resilient to the underlying
+    # filesystem
+    command += ["--latency-wait", "20"]
     return command
 
 


### PR DESCRIPTION
Often I have got failures where snakemake does not find the squashfs despite being properly generated. 
The error shows 
```
MissingOutputException in rule inference_make_squashfs_image:
Job 8 completed successfully, but some output files are missing.
Missing files after 5 seconds:
output/.../venv.squashfs
(missing locally, parent dir contents: .venv, venv.squashfs, ...)

This might be due to filesystem latency. If that is the case,
consider to increase the wait time with --latency-wait
```
The missing output error itself shows the file it is there in the parent dir, so waiting few more miliseconds would have been enough.  