### PR TITLE
Add fps setting for animation to config

### DIFF
--- a/config/varda-single-1.0.yaml
+++ b/config/varda-single-1.0.yaml
@@ -117,6 +117,7 @@ showcase:
     stations: [JUN] #, COV, GOR, WFJ, SAE, SAM, DAV, ZER, ANT, VSBAS, BRT, LTB, GOS, CEV, BIA]
   animations:
     enabled: true
+    frames_per_second: 5
     domains:
       # - globe
       - europe

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -305,10 +305,13 @@ class AnimationsConfig(BaseModel):
             "[lon_min, lon_max, lat_min, lat_max], and optional 'projection'."
         ),
     )
-    fps: float = Field(
-        default=2.0,
+    fps: float | None = Field(
+        default=None,
         gt=0,
-        description="Frames per second for the output GIF animation.",
+        description=(
+            "Frames per second for the output GIF animation. "
+            "Defaults to one frame per forecast step interval."
+        ),
     )
 
 

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -305,6 +305,11 @@ class AnimationsConfig(BaseModel):
             "[lon_min, lon_max, lat_min, lat_max], and optional 'projection'."
         ),
     )
+    fps: float = Field(
+        default=2.0,
+        gt=0,
+        description="Frames per second for the output GIF animation.",
+    )
 
 
 class ScorecardConfig(BaseModel):

--- a/src/evalml/config.py
+++ b/src/evalml/config.py
@@ -305,13 +305,10 @@ class AnimationsConfig(BaseModel):
             "[lon_min, lon_max, lat_min, lat_max], and optional 'projection'."
         ),
     )
-    fps: float | None = Field(
-        default=None,
+    frames_per_second: float = Field(
+        default=2.0,
         gt=0,
-        description=(
-            "Frames per second for the output GIF animation. "
-            "Defaults to one frame per forecast step interval."
-        ),
+        description="Frames per second for the output GIF animation.",
     )
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -201,8 +201,8 @@ rule showcase_all:
                 rules.make_forecast_animation.output,
                 init_time=[t.strftime("%Y%m%d%H%M") for t in REFTIMES],
                 run_id=CANDIDATES,
-                param=SHOWCASE_PARAMS,
-                region=list(SHOWCASE_REGIONS.keys()),
+                param=SHOWCASE_CONFIG["params"],
+                region=list(SHOWCASE_CONFIG["regions"].keys()),
                 showcase=EXPERIMENT_NAME,
             )
             if config["showcase"]["animations"]["enabled"]
@@ -213,7 +213,7 @@ rule showcase_all:
                 rules.plot_meteogram.output,
                 init_time=[t.strftime("%Y%m%d%H%M") for t in REFTIMES],
                 run_id=CANDIDATES,
-                param=SHOWCASE_PARAMS,
+                param=SHOWCASE_CONFIG["params"],
                 sta=config["showcase"]["meteograms"]["stations"],
                 showcase=EXPERIMENT_NAME,
             )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -376,11 +376,12 @@ if "jretrieve" in str(config["truth"]["root"]):
 
 TRUTH_HASH = truth_hash(config["truth"])
 REGIONS = parse_regions()
-SHOWCASE_REGIONS = parse_showcase_regions()
-SHOWCASE_PARAMS = config.get("showcase", {}).get("params", ["T_2M", "SP_10M"])
-SHOWCASE_ANIMATIONS_FPS = (
-    config.get("showcase", {}).get("animations", {}).get("frames_per_second", 2.0)
-)
+_showcase = config.get("showcase", {})
+SHOWCASE_CONFIG = {
+    "regions": parse_showcase_regions(),
+    "params": _showcase.get("params", ["T_2M", "SP_10M"]),
+    "fps": _showcase.get("animations", {}).get("frames_per_second", 2.0),
+}
 EXPERIMENT_PARAMS = config.get("experiment", {}).get(
     "params", ["T_2M", "TD_2M", "U_10M", "V_10M", "PS", "PMSL", "TOT_PREC"]
 )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -379,7 +379,7 @@ REGIONS = parse_regions()
 SHOWCASE_REGIONS = parse_showcase_regions()
 SHOWCASE_PARAMS = config.get("showcase", {}).get("params", ["T_2M", "SP_10M"])
 SHOWCASE_ANIMATIONS_FPS = (
-    config.get("showcase", {}).get("animations", {}).get("fps", 2.0)
+    config.get("showcase", {}).get("animations", {}).get("fps", None)
 )
 EXPERIMENT_PARAMS = config.get("experiment", {}).get(
     "params", ["T_2M", "TD_2M", "U_10M", "V_10M", "PS", "PMSL", "TOT_PREC"]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -379,7 +379,7 @@ REGIONS = parse_regions()
 SHOWCASE_REGIONS = parse_showcase_regions()
 SHOWCASE_PARAMS = config.get("showcase", {}).get("params", ["T_2M", "SP_10M"])
 SHOWCASE_ANIMATIONS_FPS = (
-    config.get("showcase", {}).get("animations", {}).get("fps", None)
+    config.get("showcase", {}).get("animations", {}).get("frames_per_second", 2.0)
 )
 EXPERIMENT_PARAMS = config.get("experiment", {}).get(
     "params", ["T_2M", "TD_2M", "U_10M", "V_10M", "PS", "PMSL", "TOT_PREC"]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -378,6 +378,9 @@ TRUTH_HASH = truth_hash(config["truth"])
 REGIONS = parse_regions()
 SHOWCASE_REGIONS = parse_showcase_regions()
 SHOWCASE_PARAMS = config.get("showcase", {}).get("params", ["T_2M", "SP_10M"])
+SHOWCASE_ANIMATIONS_FPS = (
+    config.get("showcase", {}).get("animations", {}).get("fps", 2.0)
+)
 EXPERIMENT_PARAMS = config.get("experiment", {}).get(
     "params", ["T_2M", "TD_2M", "U_10M", "V_10M", "PS", "PMSL", "TOT_PREC"]
 )

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -155,11 +155,7 @@ rule make_forecast_animation:
         region="|".join(map(re.escape, SHOWCASE_REGIONS.keys())),
     localrule: True
     params:
-        delay=lambda wc: (
-            round(100 / SHOWCASE_ANIMATIONS_FPS)
-            if SHOWCASE_ANIMATIONS_FPS is not None
-            else 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2])
-        ),
+        delay=round(100 / SHOWCASE_ANIMATIONS_FPS),
     shell:
         """
         FRAMES=$(for f in {input}; do [ -s "$f" ] && echo "$f"; done | tr '\\n' ' ')

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -155,7 +155,7 @@ rule make_forecast_animation:
         region="|".join(map(re.escape, SHOWCASE_REGIONS.keys())),
     localrule: True
     params:
-        delay=lambda wc: 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2]),
+        delay=round(100 / SHOWCASE_ANIMATIONS_FPS),
     shell:
         """
         FRAMES=$(for f in {input}; do [ -s "$f" ] && echo "$f"; done | tr '\\n' ' ')

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -155,7 +155,7 @@ rule make_forecast_animation:
         region="|".join(map(re.escape, SHOWCASE_REGIONS.keys())),
     localrule: True
     params:
-        delay=round(100 / SHOWCASE_ANIMATIONS_FPS),
+        delay=lambda wc: round(100 / SHOWCASE_ANIMATIONS_FPS) if SHOWCASE_ANIMATIONS_FPS is not None else 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2]),
     shell:
         """
         FRAMES=$(for f in {input}; do [ -s "$f" ] && echo "$f"; done | tr '\\n' ' ')

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -155,7 +155,11 @@ rule make_forecast_animation:
         region="|".join(map(re.escape, SHOWCASE_REGIONS.keys())),
     localrule: True
     params:
-        delay=lambda wc: round(100 / SHOWCASE_ANIMATIONS_FPS) if SHOWCASE_ANIMATIONS_FPS is not None else 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2]),
+        delay=lambda wc: (
+            round(100 / SHOWCASE_ANIMATIONS_FPS)
+            if SHOWCASE_ANIMATIONS_FPS is not None
+            else 10 * int(RUN_CONFIGS[wc.run_id]["steps"].split("/")[2])
+        ),
     shell:
         """
         FRAMES=$(for f in {input}; do [ -s "$f" ] && echo "$f"; done | tr '\\n' ' ')

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -98,7 +98,7 @@ rule plot_forecast_frame:
         expand(
             OUT_ROOT
             / "data/runs/{{run_id}}/{{init_time}}/frames/frame_{{leadtime}}_{{param}}_{region}.png",
-            region=list(SHOWCASE_REGIONS.keys()),
+            region=list(SHOWCASE_CONFIG["regions"].keys()),
         ),
     log:
         OUT_ROOT
@@ -113,7 +113,7 @@ rule plot_forecast_frame:
         grib_out_dir=lambda wc: str(
             (Path(OUT_ROOT) / f"data/runs/{wc.run_id}/{wc.init_time}/grib").resolve()
         ),
-        regions_json=json.dumps(SHOWCASE_REGIONS),
+        regions_json=json.dumps(SHOWCASE_CONFIG["regions"]),
         outdir=lambda wc: str(
             (Path(OUT_ROOT) / f"data/runs/{wc.run_id}/{wc.init_time}/frames").resolve()
         ),
@@ -151,11 +151,11 @@ rule make_forecast_animation:
         OUT_ROOT
         / "results/{showcase}/{run_id}/{init_time}/{init_time}_{param}_{region}.gif",
     wildcard_constraints:
-        param="|".join(map(re.escape, SHOWCASE_PARAMS)),
-        region="|".join(map(re.escape, SHOWCASE_REGIONS.keys())),
+        param="|".join(map(re.escape, SHOWCASE_CONFIG["params"])),
+        region="|".join(map(re.escape, SHOWCASE_CONFIG["regions"].keys())),
     localrule: True
     params:
-        delay=round(100 / SHOWCASE_ANIMATIONS_FPS),
+        delay=round(100 / SHOWCASE_CONFIG["fps"]),
     shell:
         """
         FRAMES=$(for f in {input}; do [ -s "$f" ] && echo "$f"; done | tr '\\n' ' ')

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -28,6 +28,20 @@
           },
           "title": "Domains",
           "type": "array"
+        },
+        "fps": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Frames per second for the output GIF animation. Defaults to one frame per forecast step interval.",
+          "title": "Fps"
         }
       },
       "title": "AnimationsConfig",

--- a/workflow/tools/config.schema.json
+++ b/workflow/tools/config.schema.json
@@ -29,19 +29,12 @@
           "title": "Domains",
           "type": "array"
         },
-        "fps": {
-          "anyOf": [
-            {
-              "exclusiveMinimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Frames per second for the output GIF animation. Defaults to one frame per forecast step interval.",
-          "title": "Fps"
+        "frames_per_second": {
+          "default": 2.0,
+          "description": "Frames per second for the output GIF animation.",
+          "exclusiveMinimum": 0,
+          "title": "Frames Per Second",
+          "type": "number"
         }
       },
       "title": "AnimationsConfig",


### PR DESCRIPTION
Add an optional `fps` (frame per second) field to `AnimationsConfig` to allow users to explicitly control the frame rate of forecast GIF animations. When not set, the previous behaviour is preserved, i.e. the delay is derived from the forecast step interval.

## Usage

To override the default frame rate, add `fps` under `showcase.animations` in the experiment config:

```yaml
showcase:
  animations:
    enabled: true
    fps: 0.2   # slow animation, one frame every 5 seconds
