### PR TITLE
 Fix missing label when a run is registered as both a candidate and a dependency

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -221,6 +221,7 @@ def collect_all_runs() -> dict:
                 # (as_candidate=False) demote a run that was already registered as
                 # an explicit candidate. Order in config["runs"] must not matter.
                 run_cfg["_is_candidate"] = True
+                run_cfg["label"] = runs[run_id].get("label")
             runs[run_id] = run_cfg
     return runs
 


### PR DESCRIPTION
When the same model appears as a top-level runs entry (with a label) and as a nested forecaster dependency in another run, collect_all_runs overwrites the candidate config with the dependency config. The dependency config always has label: None (Pydantic default), so the label was lost, causing a TypeError in the startup banner when joining candidate labels.

Fix: when a dependency registration collides with an existing candidate, carry the candidate's label over to the new config before overwriting.

See also #136 

example configuration causing the error:
```
runs:
  - forecaster:
      label: forecaster
      checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-1-forecaster/versions/4
      config: resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper.yaml
      steps: 0/120/6
  - temporal_downscaler:
      checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-2-interpolator/versions/3
      label: downscaler
      steps: 0/120/6
      config: resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml
      extra_requirements:
        - anemoi-datasets==0.5.35
      forecaster:
        checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-1-forecaster/versions/4
        config: resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper.yaml
        steps: 0/120/6
```