### PR TITLE
update uv.lock as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,15 +320,3 @@ All outputs are rooted at `OUT_ROOT` (from `locations.output_root` in the config
 | `{param}` | variable name | `T_2M`, `TOT_PREC` |
 | `{region}` | geographic region slug | `switzerland`, `globe` |
 | `{leadtime}` | zero-padded hours | `000`, `006`, `024` |
-
-
-## earthkit v1.0rc support
-
-The adoption of the first upcoming stable release of earthkit has started.
-Some issues may still be present. A known issue that is affecting us is that the automatic download and caching of files required
-by earthkit to support the ICON-CH grids is currently broken.
-
-The workflow now works around this automatically: the `data_download_eckit_geo_grids` rule fetches
-the required ICON-CH1/CH2 grid-definition files into eckit's default geo cache
-(`$HOME/.local/share/eckit/geo/grid/icon`) before any plotting or verification step that needs them.
-No manual setup is required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "earthkit-utils>=1.0,<1.1",
     "earthkit-plots>=1.0,<1.1",
     "earthkit-meteo>=1.0,<1.1",
-    "earthkit-geo>=1.0,<1.1"
+    "earthkit-geo>=1.0,<1.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -300,28 +300,28 @@ sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f6
 
 [[package]]
 name = "atlaslib-ecmwf"
-version = "0.46.0.17"
+version = "0.46.0.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eckitlib" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/52/edeb043d84addf89a67dc0193d7f44f62c37ec3b152662c7fb854e768f93/atlaslib_ecmwf-0.46.0.17-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:9f9361b637ed895451c0980b3c864d346e6f16ff8fdcf53ab1453d801a9dfa3c", size = 5200831, upload-time = "2026-03-31T11:58:27.069Z" },
-    { url = "https://files.pythonhosted.org/packages/98/11/e90264970f2dab35c30c956d3123594497f19c88273dd09fb1a25141e62e/atlaslib_ecmwf-0.46.0.17-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:47e5ce9334075d14718ff0eddfc3d5e3c7aaa41be7e86d5cad5d09bf26fe6c9d", size = 5794256, upload-time = "2026-03-31T12:20:41.074Z" },
-    { url = "https://files.pythonhosted.org/packages/70/92/6a81b01106892ea2be050ab06d76259626d4fe01ac60527e9eec470597fc/atlaslib_ecmwf-0.46.0.17-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:488d2a5e3ea6e46b98e250fc8618d6f41321ef2364f30adaf33fa72acf162ae5", size = 6061715, upload-time = "2026-03-31T12:05:49.863Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/08/c89ad9fa6a3dfbe8c101feb72acc71f2dda7217c0c667b2203337cec623a/atlaslib_ecmwf-0.46.0.17-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0117762f06830c0efe08014ecee18254b8cdb02ac145e1a91b42392b49ebdd31", size = 6423403, upload-time = "2026-03-31T12:08:31.483Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/bf/b586bcd66467b3edd3995996e637a32e75eb8c8dd1ecdabd3cf49445620f/atlaslib_ecmwf-0.46.0.17-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:d2a8ed1c077d06c156a43aacc5392eccf03978f1f7a71e7bca418245afde067b", size = 5200830, upload-time = "2026-03-31T11:57:31.572Z" },
-    { url = "https://files.pythonhosted.org/packages/99/7f/f63e8c43a18f2eee14400522925e6f98417cc4718a36e118357594665ed4/atlaslib_ecmwf-0.46.0.17-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:80d7079a59810f583433d3d3f6f82cc9f1307d8ace941bd6efbc8d0f0a2073ff", size = 5794265, upload-time = "2026-03-31T12:03:43.708Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/01/17a13c5805b8983e6cd8a94264b2856dae1d9ec291c6a0b5a399357a01d0/atlaslib_ecmwf-0.46.0.17-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:47ff6422ef79f86a433ea0e4d39ce0dbd88018206622093d7544d12e46d27bcf", size = 6061709, upload-time = "2026-03-31T12:05:37.618Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0c/2d6c580c950f590f0b0e6f6425f266fb05071336e6293aa5a50880c66f3e/atlaslib_ecmwf-0.46.0.17-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:29217024de397ea72d3044473988547c12b6a617b204560f2c94a917cbab22f5", size = 6423406, upload-time = "2026-03-31T12:08:41.325Z" },
-    { url = "https://files.pythonhosted.org/packages/16/7d/fcaaf77167906a56426b7b0d4b4ce9d0169c3275c097e59d17f53fe110db/atlaslib_ecmwf-0.46.0.17-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:780a9e875fd9b16ae4b552a0717c3c585e22b87a556f642181eb31517aa10434", size = 5200829, upload-time = "2026-03-31T12:17:15.358Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/9d/d6e2081db7c0b4b18951b93e3c0fdec48f4798a8a94aa8ed386342068741/atlaslib_ecmwf-0.46.0.17-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:6b07aebdd0642ee24f7629ffaabea3007435f611ee1013d856be70347726187a", size = 5794262, upload-time = "2026-03-31T12:19:37.22Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a9/88fc3160b774604501725df79b7334bec9c88ae9192848692c3c65c91269/atlaslib_ecmwf-0.46.0.17-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:dbdfcdb7212f8289be20c47ccd6ff0ba7eaa9831653d00f7789cb016de792570", size = 6061710, upload-time = "2026-03-31T12:02:39.04Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/23/204703336134c58ffcce1a009b5b1c42d4de64c10519245f74d1e41cd980/atlaslib_ecmwf-0.46.0.17-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ff565335cbf0fb14a3e5abaca646976e72d1571b1104a9b90b32e958ec66c259", size = 6423388, upload-time = "2026-03-31T12:09:04.567Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/ec/ca47ae3a4ddf05ab6bd046db84b962d7365f66fef5ac1097ac81148d30ed/atlaslib_ecmwf-0.46.0.17-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:c8b39db89fc817d904c285c57a5592da5c4a530468ff1192d8ba095a1cae07da", size = 5200825, upload-time = "2026-03-31T12:08:53.444Z" },
-    { url = "https://files.pythonhosted.org/packages/87/83/c20677147ddbceca2a0298ab9dc0f294735674732e997f67260248f2bb19/atlaslib_ecmwf-0.46.0.17-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:02f18a183000bb9e3bf1cf151ffcf9c09f4b01baf2574c43411fcad0db0d7965", size = 5794259, upload-time = "2026-03-31T12:03:48.083Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dc/f9b23429c2bd546505b5210734f8323693e39b877719f94546c8827d6a9c/atlaslib_ecmwf-0.46.0.17-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1ce76ed4ae41b47f3dff352abb91c77c187b2029bafc6eec9ce0b5daf99901d8", size = 6061693, upload-time = "2026-03-31T12:04:20.6Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/93/d9916e547fc377e9fe157e68874ed1d2dfa2f9eafae652bd51407fc72f8b/atlaslib_ecmwf-0.46.0.17-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3ce667aac70a8070f395da5be9add8ffe5d0fb312ac2dc00f18cec4d4b86b76f", size = 6423392, upload-time = "2026-03-31T12:09:20.745Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c5/d95e9d6464905d60528196dc4c068206782360006e5a9b9caea071a538e8/atlaslib_ecmwf-0.46.0.21-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:976772194a60c8662d1b68b5ffd95ea24985ee40fdef74aac47fa08f52faaf4e", size = 5200953, upload-time = "2026-06-25T14:50:00.881Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/ca/e702208b82695eae60b7f802e1321164315806a730ea8b2bc7563c5be040/atlaslib_ecmwf-0.46.0.21-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:3648c420dcd77d0dc9c1917b539d1f649d66e1746bf608c5ad779eaf7656c89d", size = 5706361, upload-time = "2026-06-25T14:39:02.488Z" },
+    { url = "https://files.pythonhosted.org/packages/15/56/472a7ef5eeca36d0c8a7c9b3ecbf3187ebd8da9b592cc95fb1f6fe219711/atlaslib_ecmwf-0.46.0.21-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:eb8924e1d2e4dd1ee91913c8c0d418bac25239edc76101ee1b04742d6f8ca149", size = 6062471, upload-time = "2026-06-25T14:35:02.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/fee738d2a6536aaf107a26385e7f6aa1b1fd133fdf5b14b82ad021cea301/atlaslib_ecmwf-0.46.0.21-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b60fd13c869d24aba5c3434f4dce2859622335a68a1c2f505706cfc22e96f72a", size = 6423612, upload-time = "2026-06-25T14:35:09.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bc/dbb64d56d1133270db1f48aa22b1c89e99cd4973f418126e0576a7ef0063/atlaslib_ecmwf-0.46.0.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:fd3a18b8a2d0a45e8fa8fa6a2611640cf1a670b21f57989849e7d0dd62399277", size = 5200955, upload-time = "2026-06-25T15:07:48Z" },
+    { url = "https://files.pythonhosted.org/packages/33/eb/831e9b9ffff109e2335d399beb5ece7e14992181d982c6edee14efd01a0e/atlaslib_ecmwf-0.46.0.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:0bc572f2cadf8f685da2f1aea7f5743c2abaee8badf933d93e75493bc8c4a0b3", size = 5706357, upload-time = "2026-06-25T15:19:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f7/0738534cc3f220bd9e1dea5d4faaffdedbd10221e1e79696bb43a68843da/atlaslib_ecmwf-0.46.0.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86b26125ac6367c4f62fd70eeb6adaa17e34a55feb96fa8631b75a778930edc7", size = 6062489, upload-time = "2026-06-25T14:36:01.008Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/4574bc9123db4fb404da02504f67e5e7f4267fc8a95351f7d50bb3d4a195/atlaslib_ecmwf-0.46.0.21-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2aed77caced30ca68380e312d3255d423aea63e28ab20d6d3ae11b3269180116", size = 6423614, upload-time = "2026-06-25T14:35:36.178Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/90/0f698714e4ef439d4da8d4575b64e67183b0c37f82789d53e224992251b2/atlaslib_ecmwf-0.46.0.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:51412637dcc546446b399817c40c6cfba8182c928edba4ef1c46c7128fd041a3", size = 5200953, upload-time = "2026-06-25T15:03:48.84Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5b/522da8438ae39ba7eff8c19711101e3a937e6419cd1102a9d7b672541178/atlaslib_ecmwf-0.46.0.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:e578b5fcde0933d7ff04b10ad8c5ac485cb29ac1d8bec471bfaa83b9b3f43941", size = 5712649, upload-time = "2026-06-25T14:40:02.256Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b6/516bdf42addf48a21e0651dec41e7ee926d1052716227a80ca7b63a1c15c/atlaslib_ecmwf-0.46.0.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:efe4654f4dcc2d454b3849a0de0f62833b67d17916f9357680a1ee5ecb2deda1", size = 6062495, upload-time = "2026-06-25T14:32:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6a/6f5665a5e3cac005dda23c445635c8aa868e8d5e3f36c77f204520d8f12d/atlaslib_ecmwf-0.46.0.21-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:36b192768f0b850b730dbdba15f28679b8e0acf77aff0843c00daf05ffaf23aa", size = 6423614, upload-time = "2026-06-25T14:35:26.189Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/64/cf63658050b3c28a628c542c073618031619cc40dd3d871c60f1238e7b41/atlaslib_ecmwf-0.46.0.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:d7851728efdde2c1751ad0776ecb1c332ff0a3a11347a7edce25ca59b9baec32", size = 5200957, upload-time = "2026-06-25T14:35:11.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/31/f99f6373c49863a2f5d24bc89dc831db1c404676c1da6b273ff30ad79a91/atlaslib_ecmwf-0.46.0.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:256e0c0045c4f238d7a7ee239f5ee8227ae3a1a6744f7037b5ab8399394e47f9", size = 5706360, upload-time = "2026-06-25T14:59:06.254Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ae/7eb9e89c2569f67a0e288ad8e7a7bf5b0405b09ca22a095d3891c7d0baa4/atlaslib_ecmwf-0.46.0.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:8577087e6fc15e5793339c6a256aba4c323a0858103ad6b0c5afd917ab69bfd6", size = 6062483, upload-time = "2026-06-25T14:34:42.284Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/1f/50cf1276f08be8576cdc771310eba027b587d07e8e432390f2761ea98086/atlaslib_ecmwf-0.46.0.21-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:9cea41ffca75cd21d869a66a97bd4b7ba5101c0aff02b62456300b5a9e8e22fa", size = 6423615, upload-time = "2026-06-25T14:35:09.895Z" },
 ]
 
 [[package]]
@@ -1033,13 +1033,14 @@ wheels = [
 
 [[package]]
 name = "earthkit-data"
-version = "1.0.0rc10"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgrib" },
     { name = "dask" },
     { name = "deprecation" },
     { name = "earthkit-utils" },
+    { name = "eccodes" },
     { name = "eccodeslib" },
     { name = "eckit" },
     { name = "entrypoints" },
@@ -1056,14 +1057,14 @@ dependencies = [
     { name = "tqdm" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/1b/0ef9638135dd1df11741425ea3a24ac4ee554c721ab11ab9de67448a6746/earthkit_data-1.0.0rc10.tar.gz", hash = "sha256:baf27366e398aacbacae3207a05fad6ca44ad88330d265b4488cabb48b7e79b6", size = 11719840, upload-time = "2026-05-13T12:33:12.408Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/fb/f5de89345c712f7e3cdb13318a3f2cbdeead35c1b2bffe6d504305d18053/earthkit_data-1.0.2.tar.gz", hash = "sha256:e067c7a0a1fc0540936df5f3fe66e6fc8568a995138022a6075d9fd260b24755", size = 10091131, upload-time = "2026-07-02T09:19:41.416Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/84/c0398bab9f29ba5c76a6c5195814b7994ef4168f49430886eb81259d094b/earthkit_data-1.0.0rc10-py3-none-any.whl", hash = "sha256:6322808b0d898418c05d6d75ba373efa741d4b529a66f7e005b709e4b1573837", size = 528604, upload-time = "2026-05-13T12:33:10.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/be/56ed3a1144d7d7cce876be1d0d2536fece99aab445facdc5fdcb893a4c86/earthkit_data-1.0.2-py3-none-any.whl", hash = "sha256:6fdc12ac3a51ff2e565477619426fbdefee94097f4b86b70638bc9c2bb1ed492", size = 550969, upload-time = "2026-07-02T09:19:39.708Z" },
 ]
 
 [[package]]
 name = "earthkit-geo"
-version = "1.0.0rc7"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eckit" },
@@ -1075,28 +1076,28 @@ dependencies = [
     { name = "requests" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/3c/a059c2b93b53fe05e7d7e897e0ac447e7c7e6e6d3b0b16afc10af8669d41/earthkit_geo-1.0.0rc7.tar.gz", hash = "sha256:c23b7633110fe47b9db83f555ead30d54e69992b467caf1aaf415bd0a0f28ef0", size = 4602910, upload-time = "2026-05-01T11:09:27.557Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/4c/5fdfb790a1b86115ee5aa5bf19e97374ce3893d6df0110f5c819214b2abd/earthkit_geo-1.0.0.tar.gz", hash = "sha256:519e9388dee1b3d53a02f8753d8387a6cd4bec9b183941fc0058369ce9b70658", size = 5094394, upload-time = "2026-06-29T08:17:01.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/b1/7a9bef00d8f679b6a1f7ba7b09ad943719204559db31a5b2633d1b426b5e/earthkit_geo-1.0.0rc7-py3-none-any.whl", hash = "sha256:50ad7a6b6d31f33f2c5819f617e2c5e8ec18d7c306fc117145b2d3d47f84ca43", size = 79330, upload-time = "2026-05-01T11:09:26.356Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a5/5954a640feb061b2c73c290da2c82d1cecffd814e9c59421582ce91eec54/earthkit_geo-1.0.0-py3-none-any.whl", hash = "sha256:b4412d01ed85955bfb54674415a768fae55efea81637d91fb6bdb9fd8ab93f7c", size = 84377, upload-time = "2026-06-29T08:17:00.665Z" },
 ]
 
 [[package]]
 name = "earthkit-meteo"
-version = "1.0.0rc3"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
     { name = "earthkit-utils" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f1/176d08c12c854efa80a1c44cb93c3680b9d70e6c9edb66771ebb5767d3e9/earthkit_meteo-1.0.0rc3.tar.gz", hash = "sha256:23014a2b93e96c16f1fad4f88ca8e8cbe1afc275dc45ba7b975a2b5506cc0596", size = 569515, upload-time = "2026-04-17T09:22:02.684Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fa/4cd7c5ff4349cb8e693177b79fa77aa25baf5a61251a5bc37b7ace2b5403/earthkit_meteo-1.0.0.tar.gz", hash = "sha256:e80c6e8d0ca1492d6f9e0c607132ce008c7ebfea3c32d55a00101bdc36ada178", size = 3282997, upload-time = "2026-06-29T08:16:16.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/4f/3ebd1e2f250de4a0248ceb41a12091845e5f886d23b3f0f764cde30f5557/earthkit_meteo-1.0.0rc3-py3-none-any.whl", hash = "sha256:e96c957d2e8954528a7f70ffe120844f0525c298798c682f9c303dcbd54e8a72", size = 144775, upload-time = "2026-04-17T09:22:01.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/be/a75b753378f4d276b68eb0b2cdafaa75ecc0069f5f94877b9dbfd181558a/earthkit_meteo-1.0.0-py3-none-any.whl", hash = "sha256:c9b3a481a1f4b58c2b18f1edfc20b68d6226cbc2713bbc4616884fbc42b389df", size = 182377, upload-time = "2026-06-29T08:16:15.042Z" },
 ]
 
 [[package]]
 name = "earthkit-plots"
-version = "1.0.0rc9"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "adjusttext" },
@@ -1110,9 +1111,9 @@ dependencies = [
     { name = "plotly" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/dd/1a4b5cb0bf8764fc29f07dc5723d0245fc0f94114144b5f813a554f96689/earthkit_plots-1.0.0rc9.tar.gz", hash = "sha256:b00358d0e47585538e4a362ec1e35728257ed088ecf1ee22913a7b1db729eb5f", size = 85895400, upload-time = "2026-05-06T18:43:41.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/04/b1226e74b05aecf97ba1f60b107d41aac22944b92fca728932761f6ce4a6/earthkit_plots-1.0.2.tar.gz", hash = "sha256:7e28b660125520d15ad7d2650a9f797e5fab15f1feeb2586e5d899e6dac13f85", size = 2888678, upload-time = "2026-07-02T09:42:17.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/bb/f15e3c46e99bda0ed2ceddccd8de9618bc90095082c700cdc48a52187ad4/earthkit_plots-1.0.0rc9-py3-none-any.whl", hash = "sha256:dce224dc8f1df892dbb9fda716c442d1659067b67c11f55e16f15a85160683e8", size = 3042412, upload-time = "2026-05-06T18:43:38.441Z" },
+    { url = "https://files.pythonhosted.org/packages/32/13/35e988595d2f577785927be7f56f5ddc5a3df44cb7fde1dcc8686e403b3e/earthkit_plots-1.0.2-py3-none-any.whl", hash = "sha256:b8a5fe0098bd227782f4b17d0bf24cee73d88e3e64ce587a8110d48f2b9c1c2d", size = 3055924, upload-time = "2026-07-02T09:42:15.963Z" },
 ]
 
 [[package]]
@@ -1131,15 +1132,15 @@ wheels = [
 
 [[package]]
 name = "earthkit-utils"
-version = "1.0.0rc1"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "array-api-compat" },
     { name = "pint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/8e/9f28a3c98709ad26683ae3b6124ccaaa932206c8fa33ab2289aab2836f0b/earthkit_utils-1.0.0rc1.tar.gz", hash = "sha256:0893be6240ae2c411991a0077a76b1a5bb744af66e9c9c106aa0cbad4e562b23", size = 42519, upload-time = "2026-04-01T10:31:49.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/ba/b4e1aeb037c11a02f68eebb9cba3918d462edb24b2ebfeaf851ef18ca060/earthkit_utils-1.0.2.tar.gz", hash = "sha256:f5e69be87ebfffb2ef5556a0f7439fee6746198c62aa3fe83498e8d327a9fa55", size = 125028, upload-time = "2026-06-29T14:11:58.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/bc/58127c74f725533a11f265525620861e63d7208a2000c0998d2f66955ee2/earthkit_utils-1.0.0rc1-py3-none-any.whl", hash = "sha256:8f1cc78cc2f9f06cdec5d31a06757c3cd56b8fba51d300f0dea3864e6f9bc8f6", size = 34708, upload-time = "2026-04-01T10:31:48.513Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/da/8a6bffefd03108c4e6ecf2390b41f18be160bc018710db3db1f857520628/earthkit_utils-1.0.2-py3-none-any.whl", hash = "sha256:eef89a1f6a3f03d4cca2b82975a3f4548d3db43a17646014952453b00d98edb8", size = 41054, upload-time = "2026-06-29T14:11:57.626Z" },
 ]
 
 [[package]]
@@ -1167,79 +1168,80 @@ source = { git = "https://github.com/MeteoSwiss/eccodes-cosmo-resources-python#1
 
 [[package]]
 name = "eccodeslib"
-version = "2.46.2.17"
+version = "2.47.3.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eckitlib" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/c4/8fad6eb2239247d843e4c882714d75dd99c2014e53ca13ef9528d946e962/eccodeslib-2.46.2.17-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:e688a59a38516e6acd723ef18e04f6e429a1ac24fe56e0248854a0bb01d10439", size = 8899985, upload-time = "2026-03-31T11:58:30.222Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/f5/6c8467259d9a972100fa6d8e090243a01d92a2cde2521f73958a202b8bba/eccodeslib-2.46.2.17-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:3c83f262103d251b5127b6a6f07d6c7aa9da75502fcc6cdfe045134263835422", size = 8731411, upload-time = "2026-03-31T12:20:44.518Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c5/a4a5a12c0ae1aefb745f49b3fb024806605f4ae7dab14ec6bda7b733b727/eccodeslib-2.46.2.17-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2b1de2274e43ad25793b5898e50d0f11668d01bb07908e490617561461c65eae", size = 9093682, upload-time = "2026-03-31T12:05:52.737Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/34/ea727c8090dfdc4b340f7f4d26b1ff536690a5dcb13cb2591c1eec9227b6/eccodeslib-2.46.2.17-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7d6fab20983bf61ac32b77fadd045eff9ba9d6e9434cbde326215a4f104e0843", size = 8986653, upload-time = "2026-03-31T12:08:35.395Z" },
-    { url = "https://files.pythonhosted.org/packages/45/1d/8a748d17435cd3db912e6433913cba8ced32b35c84d8b2617a976545c3a8/eccodeslib-2.46.2.17-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:48f97854c8764cbfdb961fedaaf48fe09e03a31dd8fcded7b1be14d4bfbb6c8d", size = 8899939, upload-time = "2026-03-31T11:57:34.793Z" },
-    { url = "https://files.pythonhosted.org/packages/75/d7/6debaa856d92467338ed034c241e388fdb806c2a9bbf855c1753a5168a9f/eccodeslib-2.46.2.17-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:1edd433081cb25e7986fc6aefb35dc12a1d30f760f3ffdd9e5c34212a1223397", size = 8731411, upload-time = "2026-03-31T12:03:47.23Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/22/05436e788e83c54595385803d08a4fa63fa2f89a2cd221906acd39645b12/eccodeslib-2.46.2.17-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b6897c96a3fd64682b83c19f894481c8234e8c84de3587dd34f799c2e14c8b1c", size = 9093681, upload-time = "2026-03-31T12:05:40.418Z" },
-    { url = "https://files.pythonhosted.org/packages/15/bc/466360995a54cdffafc20fcc74cac9591d06dbeaad7765fa32de6ccdfebe/eccodeslib-2.46.2.17-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfe6af14b4c276b57b7f9bdf4a9fcfc235cbbd62fb53597a251228abd944aac2", size = 8986650, upload-time = "2026-03-31T12:08:51.586Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f8/d5613341dfeeb3dee9ead4de6c3f9cfc3eee2735a1170ba91a2f5cfe4d40/eccodeslib-2.46.2.17-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:d2970546bbbc01bace6d6e9805b2c139852453983c8662951179c55ca171c818", size = 8899971, upload-time = "2026-03-31T12:17:18.328Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/63/286782b25ce38977edc9a5b08d6ef39156984f618b3ac4292b2ddb93b6b7/eccodeslib-2.46.2.17-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:833bb65c264288dfad61773dfddd9e467063ff69b3924229453d4638baa4a3e7", size = 8731429, upload-time = "2026-03-31T12:19:40.681Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3d/d770243f073a050b36f7472d086737a0778f1d1e2815468966c4db8503f2/eccodeslib-2.46.2.17-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c5ce4d0027ea36996568fb9ac8a527ebfae04212d45a527d5b6fff56decace2a", size = 9093680, upload-time = "2026-03-31T12:02:41.9Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2d/db7de53736a5403db2856d13db6cc55ee8ec52c171d00e7dc8081b165e58/eccodeslib-2.46.2.17-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0dffca7872012f1abde029e929c82a2d24ec094c75decf34a229f9806baa3257", size = 8986652, upload-time = "2026-03-31T12:09:09.145Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/2f/a9a0cf3a9ac6fe2b917e9da997a67d32c7dd70d8c1db57da7579d5904649/eccodeslib-2.46.2.17-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:6b42e585c5147e2f34fe3ef986ed909470c912261f9643aae78bf73b888fbc88", size = 8899955, upload-time = "2026-03-31T12:08:57.367Z" },
-    { url = "https://files.pythonhosted.org/packages/60/d8/2bd8b0ecfdbfaa2627679d8649ba8dc5e5bbf97c64248e206abcb486c2fb/eccodeslib-2.46.2.17-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:586c62aeea0a57038670a9e56fc5fd698340a63942c2fc9c39bbe2451bc5812f", size = 8731408, upload-time = "2026-03-31T12:03:52.343Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/d7/c1bd8b1551816ae918c5b98a3dd2e24e64e70bae2a05d591cbce0ec86f99/eccodeslib-2.46.2.17-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:60294a7b8e3f7e7e4c4010a31c07530880f5fe4899080765e3cb4f918507d2d8", size = 9093680, upload-time = "2026-03-31T12:04:22.757Z" },
-    { url = "https://files.pythonhosted.org/packages/54/48/df4010ff2b2e1ddc750b764560f2bb5cf37d1e32caadc34e3e12fa533e80/eccodeslib-2.46.2.17-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:79e5b96c47646e054d37f372604c43b7e1bdab727da2e55a17d01ca1759fddd9", size = 8986653, upload-time = "2026-03-31T12:09:24.851Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f0/e632b43e69e48ba6d2ddf499d44008fb3482302b42f68fe94dd2fcabc2a5/eccodeslib-2.47.3.21-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:f85c7adbdb69e7301a4c134664bc2fc4dec08d235c15135bb7ba910120cca13c", size = 9028159, upload-time = "2026-06-25T14:50:04.148Z" },
+    { url = "https://files.pythonhosted.org/packages/73/24/16239a49d1925705f4c4381412f893aa711b80ec45c892c8f9a09263713b/eccodeslib-2.47.3.21-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:e36af63f3c61576722e49ba440cf81edf5f86f38b0acc026db911925222a064d", size = 8838802, upload-time = "2026-06-25T14:39:05.932Z" },
+    { url = "https://files.pythonhosted.org/packages/60/21/72a3db13d74ea6307d84bdd239bfc5c8b63aa334b84286b1136566be9835/eccodeslib-2.47.3.21-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:e5eb64ed8ff3a70138fb39570132dbbe5c4254001cbe823694adca08cab9a7eb", size = 9112804, upload-time = "2026-06-25T14:35:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/2d298f36465835ecd499015ce01d2917aaa4e55f56cf92545e45a6fc2d7d/eccodeslib-2.47.3.21-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:552a5903e2ec5c7bea8a730c1875633821322a333352f2b3b782041e648cbde9", size = 9012384, upload-time = "2026-06-25T14:35:14.095Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/63/815e2b04527beb484a1fa9a6e2078f0ebf91be170f30518c008097b8e22f/eccodeslib-2.47.3.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:6402dd5e0ca46999b362d570df0dd53d2ca82421b8be8239dea9ccc5d37a9783", size = 9028141, upload-time = "2026-06-25T15:07:51.154Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/8b/ff69d262638253368779b56175c0bad7d75c8fe4892f91f84610847ab705/eccodeslib-2.47.3.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9c5b04f70bab30188ea51e40387d34cafb01af77035f768e0d0a49443e73b3ae", size = 8838806, upload-time = "2026-06-25T15:19:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a3/73ad3e28852d865012c1f27aa0ea83d07bf6fdfb8ea755b3b44d462413d5/eccodeslib-2.47.3.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2404c0ab63b52b56ba7b9293e227784c2f70ae378d29d925391d10512175419f", size = 9112802, upload-time = "2026-06-25T14:36:03.94Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/55/d1daa7be3f51e766d63a63d187f02313a785b7d407f09ae70eb8634e91ac/eccodeslib-2.47.3.21-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a695c897882a63609a5ec655bf526f5acd633969bfde85b4d1ccf347069afad5", size = 9012383, upload-time = "2026-06-25T14:35:40.158Z" },
+    { url = "https://files.pythonhosted.org/packages/17/48/482d1f7b89b59a16cd2a92dc9f7de0bd018b96de02c992d47ff03b45cc65/eccodeslib-2.47.3.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:0b7801f2a34ae49a125941509b3645a31e489a25fc34324f0dfc8d5eca99d1be", size = 9028142, upload-time = "2026-06-25T15:03:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/24f1e1551e2f9a853c9ee68996132e609278501b2a87d4296c8c00c4c829/eccodeslib-2.47.3.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c4bdea8eda9b2194d0b1f797b54c0b42e9b0833c940c0677fcbf7965855add59", size = 8838818, upload-time = "2026-06-25T14:40:05.602Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4a/37aad5c0da3b15c456d2ad5b3d0ef3cdb58ab6eb94150bbd86549fea2af0/eccodeslib-2.47.3.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f8e5615cc7b6dcd74e42ee7df63765bd122662fac972c21cc011db094fd33617", size = 9112803, upload-time = "2026-06-25T14:33:01.943Z" },
+    { url = "https://files.pythonhosted.org/packages/14/83/a961cbd2750e5481f642b71260581111f07c19a4c79748740a77482a01fd/eccodeslib-2.47.3.21-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d797d87640971c243b351de0a2f87c4af9d94a2a6160af1b48bb2ee66d781b7f", size = 9012387, upload-time = "2026-06-25T14:35:30.127Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c8/c01eb1ea558099fc34412740a1a856cf74f08cdb86c999c102652f3e0cb0/eccodeslib-2.47.3.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:12b1ada1078a40a28b12e4c0b906eee4599f640e205e5172a6ac80243d2cd4c7", size = 9028130, upload-time = "2026-06-25T14:35:15.853Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8e/50442c597f7fe2bbd7617486d46b8b16cab66c664434dca2392ebf8b7f08/eccodeslib-2.47.3.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7fb9fee37cddbc7288505fc717c620149f9960802099efe1b1ba866825cd16cc", size = 8838822, upload-time = "2026-06-25T14:59:09.769Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b1/439d03430637f2e807fe6f24f70532a0af41da78e5355e58bf8efd20dbaa/eccodeslib-2.47.3.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e7a46a2ee488fcfa34e4b4b2df963029606d1d2f2b2be17b8accc2df6a6423ed", size = 9112804, upload-time = "2026-06-25T14:34:45.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/3d3df398358741e05e42d4eaed9155ee05672868cd6e85ad3cfb92280a67/eccodeslib-2.47.3.21-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:29b828fffaf5eef6a8b7e09fc956cc164293e7438a20fae66c4710f06e6d4518", size = 9012386, upload-time = "2026-06-25T14:35:15.443Z" },
 ]
 
 [[package]]
 name = "eckit"
-version = "2.0.6.17"
+version = "2.1.0.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eckitlib" },
     { name = "findlibs" },
     { name = "pyyaml" },
+    { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/2d/18ce679569ece3dd8192a1e2b1a6a7267b13c2e812b6e457fc79cf7b8ff6/eckit-2.0.6.17-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:73df6900fdfd2931e559f1d1e49c4650afe296d2b9420a509796c8d6cac28480", size = 45191, upload-time = "2026-03-31T11:58:32.858Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/0c/b1a7dd95b8b6a3dd63601ed79a61b015fa67b4ffa8cc70159a797329f1fc/eckit-2.0.6.17-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:b4c29e7b15203169150129fa86e7948c3fa1867b62dc33b0177d6e395d7499c6", size = 43192, upload-time = "2026-03-31T12:20:47.555Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/07/68a65985966073e3e55a9a2910ca9ebb9c09a228c7b9b5a0635199a3faf0/eckit-2.0.6.17-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:55b2b2df151d6cca5ee4f22c4cfa0d6093f60fada9bb3929057be121f9c53680", size = 333413, upload-time = "2026-03-31T12:05:55.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/c1/94d0cfb2ae0be6ea8bf21cd76f392e166ef00597312f6fd92e789089e7d8/eckit-2.0.6.17-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1d6125002cd1eec7144d2a7e7fc013b087880ee6d019831f8cfa5e662be942a7", size = 331302, upload-time = "2026-03-31T12:08:39.142Z" },
-    { url = "https://files.pythonhosted.org/packages/73/57/c525eab48c77141e59b4ccce8ec4eaf10ff37eda16ee170a8a0ac3e8c08f/eckit-2.0.6.17-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:8ec1edbac061902333190861e5e8718af5ad922d3a1fd76e910e5dfd0f35671d", size = 45844, upload-time = "2026-03-31T11:57:37.871Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/90/b839f0f89ea993fa06aa3b678bb8f9df02a9ef3be2fc5255e3a272f9e0d1/eckit-2.0.6.17-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:481313001434f83fed7dc8186dfa6ed6b058e39d83feb0b339a69c712c6d497a", size = 43799, upload-time = "2026-03-31T12:03:50.052Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/9c/a98f3082e71ab35cda4fd46912b3eeb0608c4def86a982a58899ebcf940a/eckit-2.0.6.17-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:01ddebf81d68c493e8cd730c83dc31e5262aae8094f53d5e593411423c07a818", size = 346383, upload-time = "2026-03-31T12:05:43.095Z" },
-    { url = "https://files.pythonhosted.org/packages/16/e0/95ab0c328d601e95fa7f628715d317851f38350385336fae204109d72412/eckit-2.0.6.17-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:091facda7c9abc68a39ac6f184b9515555026e9456f88a74f57dbcf72fad5935", size = 345944, upload-time = "2026-03-31T12:08:55.079Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/58/9ddc84396833cad8ba32ee45b58bf3ee74367acff0d5e92b2e65878fd324/eckit-2.0.6.17-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:c8c9832fe8c324a150488093511868f636bc9a22d7d135664502e2aab79a1776", size = 45323, upload-time = "2026-03-31T12:17:21.036Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c6/c7c738f18e4f9f363d86a51e617e11ff8faf6e653604bffe6e0d7e0a4d3d/eckit-2.0.6.17-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:f9284cffe347521033da1558a6c193542617e931b87c375a8b084813c1eeefac", size = 43466, upload-time = "2026-03-31T12:19:44.012Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/72/aa9903cd765ba29651b5097e6960849bb489fd9a7cbac62a22ed0a7206b3/eckit-2.0.6.17-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2b95175f73ebf348cb58e4dbcc72f54aea4860428e36da225fcaf8158457cb97", size = 343022, upload-time = "2026-03-31T12:02:44.136Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/c0/ffbf40a987fb26d15e0cc4ca0986c64fdf35789432f15150a3a9b393b9b7/eckit-2.0.6.17-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:575dfecdf953a13ad82ab0d47790ae5c3e72e56fcefe96f7fe68fad48c0de3cc", size = 342194, upload-time = "2026-03-31T12:09:12.933Z" },
-    { url = "https://files.pythonhosted.org/packages/85/d8/e8579f206aedaaca36697f7705b871d107ad8bde7493ba9ea29775716e77/eckit-2.0.6.17-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:a8b8319371d58dd86aae7393fb29e29be99895d4e8c418d515a2f682131e4b58", size = 45840, upload-time = "2026-03-31T12:09:00.219Z" },
-    { url = "https://files.pythonhosted.org/packages/77/5c/a1485730b7007687123eab5b68e5b80c67c60cf79757c275a790bb6f97c4/eckit-2.0.6.17-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:4b5d4867733813edafb4ee9ef62fbb335800448be93bb18f15cfed1fa1cb61b8", size = 43752, upload-time = "2026-03-31T12:03:55.572Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/fd/c243fec55cbc8c6fdc67c582a1c2f99c6b4d0c78f10caedb79a87cf0e25e/eckit-2.0.6.17-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:3e606012f68ce2a36dedd7decb55705c637c240a34bd1af3b1dd4e4f6ab8dc0c", size = 342046, upload-time = "2026-03-31T12:04:25.219Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/10/d6ae9304c2fd157dfe8396187c9a98c9fe5003b329c99984e90b6b330d9b/eckit-2.0.6.17-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:631d44907208f490415ccfac1cc659f15effbcef5cc2552c22db2a0495bd0624", size = 340290, upload-time = "2026-03-31T12:09:28.411Z" },
+    { url = "https://files.pythonhosted.org/packages/91/06/eea5a0030059ebcabd03672d80aa38ac67f0f201d63bda5aa7cd36ed62a1/eckit-2.1.0.21-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:ab52004a58df4ce9a31b514ca179988b00c975682ca4cda3117919be494bc113", size = 62264, upload-time = "2026-06-25T14:50:07.012Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/97/0b614972c12a5600314eba56739a32e1c300ea17a49b77cf36381557d00d/eckit-2.1.0.21-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:664200c370a6d067b255d76eb6b7350ec2f55b38054a980e3344d4d896c4ed00", size = 61067, upload-time = "2026-06-25T14:39:08.856Z" },
+    { url = "https://files.pythonhosted.org/packages/75/df/5e733aad55ddf77d32d976d141a993477dc94c97dbe9887d25f6f644d65e/eckit-2.1.0.21-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6baf62666f029d9521677661e4569824c623d2893c32a734015ac368efaa932d", size = 67171, upload-time = "2026-06-25T14:35:07.619Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0e/43413cecca5cc6a93f515ca4fb3279d66f8e13115c616083ea51f25ed6ab/eckit-2.1.0.21-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7c6464c1f103aa58b5afd398423088dccdf9c17767109a5283a400579856178e", size = 66610, upload-time = "2026-06-25T14:35:17.378Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4b/0310b509f8bf5bd090cd68457f76a6b51664bb9a95a0519d04881b1bd326/eckit-2.1.0.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:6f49484ffe62b2d8d7b113c1a1c63f558061a5ac3972b0a5fa62ba1124855a30", size = 62799, upload-time = "2026-06-25T15:07:53.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/018a16f52440e568613abd676156a3f86bdf4084c5b42004651a4668319b/eckit-2.1.0.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:da2f9f5ab6aa7067aa4a7f60f61a889e4bc5565b2091eb6ea34a5fccd5bf354d", size = 62350, upload-time = "2026-06-25T15:19:56.526Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9a/9709c3ffbf314ba16415402b5e2bd09bab3527d77cd874fb8b06bc1d4236/eckit-2.1.0.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:272a355537df37dcdd8ce88ad1fa4c6992b89302a9597e60f609bb0e0f60b623", size = 68768, upload-time = "2026-06-25T14:36:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3d/a36e7076a2c86f4f02ba144f0e27bf04054c078cb74b29fa78834acd47da/eckit-2.1.0.21-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:caa4b92dc7e8535498182a0a20e2b365592ff56b470e40e351ef63c77980c3ba", size = 68344, upload-time = "2026-06-25T14:35:43.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/66/e6d41f0338f4bef469134ff2643a22c89dad5c75f41e8b4c5eeb32db3b47/eckit-2.1.0.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:325d71760af22dcdca8a9b4d85ebc03411eb585941f57e7e98c9d29903b2a6cc", size = 62440, upload-time = "2026-06-25T15:03:55.197Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/66/deb51bf3ac3e1f631147aed39569525507cc1539b034fec9d629e2e188af/eckit-2.1.0.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:21d35376dfd3a36c5fb716ac4c3520e0e6558a68a0564d3c7e42d4ce7bafe80a", size = 61837, upload-time = "2026-06-25T14:40:08.583Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0b/6c9ff5198954f9a7bb07115254f9ade38469ca2be2dbe807aef7eaf61685/eckit-2.1.0.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a2caeb9e5b5347f55d02928f625e886fae6c56fbd1de9698b2f83c3a39b6a883", size = 68773, upload-time = "2026-06-25T14:33:04.473Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e0/def5930af95ff1fbea94dfb257bd85b7544d08d05c050dd11f5bc6062a2b/eckit-2.1.0.21-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2f05013dbe37c9a840cb7f75ca8ca95497d9f2f77f13a747f9a3c46926a77402", size = 68394, upload-time = "2026-06-25T14:35:33.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4e/2d4ffa54fe34462611277738a4268f9d8dd097600ebe73acf0980e754a80/eckit-2.1.0.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:0433ebbed2db97145b2c1729efb067a20b4fdc8e71a3310dde7585d4ba8f7e0a", size = 62965, upload-time = "2026-06-25T14:35:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/fe/a2a6513f3d283597be1b561ed9c1f746d1937d4f5da3bed1bde997616080/eckit-2.1.0.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:56a3b0f81f738c0d251a63aba65c64524776789183188e2616771e58d7ab846f", size = 62180, upload-time = "2026-06-25T14:59:12.905Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/eb/756706ca35b36215c8f105bc44c2f9276058c269e09a58b78959dbd23517/eckit-2.1.0.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:288ff903cb40998e554e28699ce380a03672a6b21a94d1e583e5cadd6ff35b22", size = 69170, upload-time = "2026-06-25T14:34:48.33Z" },
+    { url = "https://files.pythonhosted.org/packages/68/05/3cbfc829ceda8da7e10941bc1c7fa4fccde13deacc52656ff174ce7a8aa8/eckit-2.1.0.21-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ef55eda6366dd7462706a114133120d77afd3242f480e69e9bf2b745e206daa1", size = 68654, upload-time = "2026-06-25T14:35:18.968Z" },
 ]
 
 [[package]]
 name = "eckitlib"
-version = "2.0.6.17"
+version = "2.1.0.21"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/4b/9e9c61ff0de16d875fd0ea5f0f8f76743b048ca7067193828f598d9cd28f/eckitlib-2.0.6.17-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6ad9d0f3615a9b404e238e2de590a7f1434ba1a2400deaafb70307cb49956785", size = 2476467, upload-time = "2026-03-31T11:58:35.281Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/8d/48be6774dd223c39eb602b10aa8a0e16548d64b5d685e868df06833bc68f/eckitlib-2.0.6.17-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:fa2549d980f03a61f3c878d8da2f0772443e963021fd0bce77ec8faa372809ea", size = 2607337, upload-time = "2026-03-31T12:20:50.174Z" },
-    { url = "https://files.pythonhosted.org/packages/49/5d/56411678e2f2cb7a8949ab19c54a55e256a277e51cf260a231448ba74ea7/eckitlib-2.0.6.17-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7e57d229f7aa83e64b2c289c341c241300e029b2758ac3a50beb7c1d8c73b91", size = 7036910, upload-time = "2026-03-31T12:05:58.022Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/f4/39b3f8d408247c888e976c5f1fd5a05e60736e4f3b462f5df90386c9d8a0/eckitlib-2.0.6.17-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a1df4b692be3ed29dfea6d209e03eee60ce6321d8c17638ba35979e4c5a834", size = 7165487, upload-time = "2026-03-31T12:08:42.908Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9c/7cba6d95e3fefee7b8ee5d0cb088cb65633044b66868f5d69db489e28999/eckitlib-2.0.6.17-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:994f0920fb3cb783bd20be405600380433a917a35ce77fa233a3f52f58faf3ed", size = 2476471, upload-time = "2026-03-31T11:57:40.752Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9c/47195a91bacba462ed35be30ddce02047314eb79eb7ebe20e50a83a87ed4/eckitlib-2.0.6.17-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:f2e8c2e70210f4c25f8070ecd9c06c2004408bbe914a1f3f5bd1a90b17706a0f", size = 2607338, upload-time = "2026-03-31T12:03:52.736Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/d9/1e4768dd341d174cc468c383ed89c4ecf0fb6eb7d2d51b05cb417a896dc0/eckitlib-2.0.6.17-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0be46782ae05c67a7932801a2106166f0b1e03ba5329ab3b5a39455062172d0", size = 7036915, upload-time = "2026-03-31T12:05:45.702Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/12/12f921c7851e0bd58deecb873b827f75e8c98907d529b2ad90b6118220c2/eckitlib-2.0.6.17-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3157fda30bf2d48c3f176e3086af9312abe01b5f823d907a701d01e9956050f", size = 7165492, upload-time = "2026-03-31T12:08:59.317Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/30/c0e723521c8a8f5d3505e30f4d69eff6c4b1eb86fe1e3cd62ecba3b366b9/eckitlib-2.0.6.17-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:b26209e18d14f2d5c8638500529d0567e3333a5bfd50139f8b2b9cd56999236c", size = 2476465, upload-time = "2026-03-31T12:17:23.662Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/2f/f3f88987fda5d6b824b26e7fb945703b42b3c76642291ad497dff74dfa35/eckitlib-2.0.6.17-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:ab14bd32bda4780a90e18f887cee5ae9c45b3f6ccf70394ed90ab723837841af", size = 2607338, upload-time = "2026-03-31T12:19:46.989Z" },
-    { url = "https://files.pythonhosted.org/packages/77/54/1545234631273aa4b55df0f0867efd4a5730419b73da080a8ed394a9be81/eckitlib-2.0.6.17-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20d3b06681a9c7262078953a238d12a732e1e5096367fa89294c9941a666610a", size = 7036922, upload-time = "2026-03-31T12:02:46.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/42e430a589be2d86c2b881e2597512669197f5f465b97548697dfc474cb1/eckitlib-2.0.6.17-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e3e87e537e2e941b32a1b60880afbead3681e62da7792d211cf5a62831eac94", size = 7165490, upload-time = "2026-03-31T12:09:17.633Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/9e/9c956438266a3ad89ef7c7ed98755fbc73d9a1ab893c8f75864dbb107ea6/eckitlib-2.0.6.17-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:d85e89b1444a6eaae8a5cecf56d3bdd8c3ed6eb5eb1c379e8616168eb69fe68b", size = 2476469, upload-time = "2026-03-31T12:09:03.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/59/6796f2814364d1485b023687ec942b259b28b0d236ce3946cd8aaab04670/eckitlib-2.0.6.17-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:b64cc7dba2597fd84b5fed3a38c51c3e47d4ff2841f37a9587997f8f68f2a47d", size = 2607338, upload-time = "2026-03-31T12:03:58.253Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/0d/b321332d045eb43a408949d6aa95dacb8e010c0daf0cc826b5fbe2cb5ead/eckitlib-2.0.6.17-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:db1fa6e7c63ec783129ecef9492e484498c4b7009a349a1f3b1e7d46252016bd", size = 7036913, upload-time = "2026-03-31T12:04:27.091Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f1/199e2dd0505427ed34ac56563aca5de83f704a17f36556f2e5cbe6edf942/eckitlib-2.0.6.17-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eae219b500c8c13d7c06411a66c04ecdfa2b6d3c25d2be08977723b56ecedc42", size = 7165499, upload-time = "2026-03-31T12:09:32.072Z" },
+    { url = "https://files.pythonhosted.org/packages/81/03/b2e458d6c28b3905146cf0d7b15c37ba66ee38cefa87c31043f73568531b/eckitlib-2.1.0.21-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:616279096f54a466871c00db51f8657088a531f648035bc1ec019f494a5a4b58", size = 2486603, upload-time = "2026-06-25T14:50:09.66Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ba/d10694f7bfcdb7de461d78b2e23e0ee4c86b747bb233f4c8c8181a695960/eckitlib-2.1.0.21-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:68fb850cb5b740f0858b5f32be4fed874ea8aa92f87ccb1fff292e7cb359fafe", size = 2623459, upload-time = "2026-06-25T14:39:11.554Z" },
+    { url = "https://files.pythonhosted.org/packages/79/01/0f1d3b1472dff0f2f00d92135815f46e53af99eb229dccabaf6299da3e9f/eckitlib-2.1.0.21-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7aed097bafc22389cc83a5376539c7c4003fa6c868775988ef8fbcf2b772d172", size = 7044388, upload-time = "2026-06-25T14:35:09.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/40/7b4c3d6473df5fc73677e0f185f9fbb6262536939b90adfa176bdd485389/eckitlib-2.1.0.21-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9e0ce2a62b606ae92b0a16c3867ab19d1a0680ae7ad9e64ac5c5d779577eb5e", size = 7172300, upload-time = "2026-06-25T14:35:20.729Z" },
+    { url = "https://files.pythonhosted.org/packages/49/48/855090b6c5830db955255234dd181ba2b536a504f7582d2a21d5139864c0/eckitlib-2.1.0.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:25af6bd0f184543970c235047d05aafb4336ef921fa2e22052f7af2b2992b66f", size = 2486612, upload-time = "2026-06-25T15:07:56.142Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b8/4ad8aaec202414ff864d8c899be473821a6922d4e470076d44d7feffd181/eckitlib-2.1.0.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:bcbc57a01ade90da0380c2708001d2f067e9b9e2288db54e2ed1d05a9a6dcd4e", size = 2623455, upload-time = "2026-06-25T15:19:59.363Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/11/a7601e467cb3a598c507324ef4ae0df474f054c807653ad2ea0ddd7ceea6/eckitlib-2.1.0.21-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b9fc94a791cf279442d531b477610b5d904ffdfb398d1ed23cb6bd3f99f225d", size = 7044403, upload-time = "2026-06-25T14:36:09.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3e/df093e61e485c80cce3bbde4ba5281d7bd7bd2f720f6d9a221b59f079ea7/eckitlib-2.1.0.21-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0bfd207a7cc4c14f5c80d64eb2b99082282aa0b7019201f9a3f077d6a3bc09f", size = 7172282, upload-time = "2026-06-25T14:35:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/26/83/3057ecdfaa33f502856f318b7fa0ac787219800c8b1d32edb137479105f0/eckitlib-2.1.0.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:07cf9eb202345928b4f2cd065042bf9576a7b6d090edb660bd2e18cbd3ee7525", size = 2486606, upload-time = "2026-06-25T15:03:57.534Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a3/6a61f92c74ac873416285d5407097a8feff0979a024d0c76d2e3f161bf50/eckitlib-2.1.0.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a91c14f270a120b08feef06f1b1a8cc47015d4ac4f58fed623c12762ca9c9a8c", size = 2623462, upload-time = "2026-06-25T14:40:11.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/2bd0142d9b2a0858f71bc96c53403c1c902dcefb806229fb4c72d42ac4ea/eckitlib-2.1.0.21-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf09a9832cb839017a3276389a6c7e626674e3ec174e545642fbadf0cbaec136", size = 7044397, upload-time = "2026-06-25T14:33:06.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/97/2e9a04da4cead7497a6d63dd24c5c2344cfabc389c3115f5508759299d46/eckitlib-2.1.0.21-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e81dbf594da7b78e0cb8b88e7ee69e115c640a4fe3ab239dbbccd8f73326009", size = 7172280, upload-time = "2026-06-25T14:35:36.536Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f3/e65b06d676872f0616dbc903b4ff10192f1e65b5762440a85131a3517551/eckitlib-2.1.0.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:7525dd7f8386ae12949532ab20587ef1aea5d12b0604188cfc35a557171331c5", size = 2486607, upload-time = "2026-06-25T14:35:21.956Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/11b861efc359a38ef9ca1206235f5319669ee42ceed197c44403339e69a7/eckitlib-2.1.0.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:2c6da56832610be3a449bfa9fe56bc760135468856a3ed45f89a217801d4f798", size = 2623461, upload-time = "2026-06-25T14:59:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/23/bd23c7aa50bdaf46ca81f5c656f4e0f3b136fe2c51d52870946b6675c110/eckitlib-2.1.0.21-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d210fce1ab44715f6e7080305836bdb2e499bdf2e0bb66cae326b57cae3e8de", size = 7044383, upload-time = "2026-06-25T14:34:50.86Z" },
+    { url = "https://files.pythonhosted.org/packages/74/70/6b5abe1f726eb95e6c677dbbefe0f673707c1a10e514b96d3f4c9c38b38f/eckitlib-2.1.0.21-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17169e998b1839c57eb0716b33ffc9fc2c47b5aa5525fe14ec7c623fcffbce5d", size = 7172279, upload-time = "2026-06-25T14:35:22.195Z" },
 ]
 
 [[package]]
@@ -1291,11 +1293,11 @@ requires-dist = [
     { name = "anemoi-datasets", specifier = ">=0.5.31" },
     { name = "cartopy", specifier = ">=0.25.0" },
     { name = "click" },
-    { name = "earthkit-data", specifier = "==1.0.0rc10" },
-    { name = "earthkit-geo", specifier = "==1.0.0rc7" },
-    { name = "earthkit-meteo", specifier = "==1.0.0rc3" },
-    { name = "earthkit-plots", specifier = "==1.0.0rc9" },
-    { name = "earthkit-utils", specifier = "==1.0.0rc1" },
+    { name = "earthkit-data", specifier = ">=1.0,<1.1" },
+    { name = "earthkit-geo", specifier = ">=1.0,<1.1" },
+    { name = "earthkit-meteo", specifier = ">=1.0,<1.1" },
+    { name = "earthkit-plots", specifier = ">=1.0,<1.1" },
+    { name = "earthkit-utils", specifier = ">=1.0,<1.1" },
     { name = "eccodes", specifier = ">=2.44,<2.48" },
     { name = "eccodes-cosmo-resources-python", git = "https://github.com/MeteoSwiss/eccodes-cosmo-resources-python" },
     { name = "geopandas", specifier = ">=0.14.0" },
@@ -2463,36 +2465,38 @@ wheels = [
 
 [[package]]
 name = "mir-python"
-version = "1.28.1.17"
+version = "1.29.0.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "eckit" },
     { name = "findlibs" },
     { name = "mirlib" },
     { name = "numpy" },
     { name = "pyyaml" },
+    { name = "scipy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/c0/6cc45189f61bff04ca6b15cb5651234c9d48a03c15cd0ef2e219ace44751/mir_python-1.28.1.17-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:bd8a242d4690cfa26fa0c08beae7cd442956e0c848c8d020a83a34e7d49c4ab2", size = 140868, upload-time = "2026-03-31T11:58:43.038Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/89/846a08468c5f595e76183a1ab37bb1d24444983def7334bba9533ceff2c7/mir_python-1.28.1.17-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:4ed7974d2cdfa4e774b3964f9e1e991bd3bc2bf587f6e22e976f8b6f532c5ce1", size = 144554, upload-time = "2026-03-31T12:20:58.551Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/b6/44ee8182227d7b8965183c390ab19c984604cb38c83529e22f282d197239/mir_python-1.28.1.17-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:820252a30cfa862f9481c4792c76a424fd5ba38189a8788e6517d5e1139b3a3a", size = 1186780, upload-time = "2026-03-31T12:06:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/05/f9/69b3989e44e57f67f8d27a16bf61a0c7ad2247745ca59e157016ddd93a93/mir_python-1.28.1.17-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:740561316ee1bd740a80bb17a6aec9bd0a08de84e8342fcbe791d275ea49bf07", size = 1199889, upload-time = "2026-03-31T12:08:56.16Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2c/bb7b711dd4476768fada466cefc7bbfc727501bed57a3e78b11269cc5195/mir_python-1.28.1.17-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:3e9d491b3a1b5abb0d0eb236db5481687343078e063330b011c77e958f50942f", size = 142524, upload-time = "2026-03-31T11:57:49.375Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/54/c9cb3064f274b89c9d871940f82ec48c1ad14187618f00243496d7b31698/mir_python-1.28.1.17-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:b1cf5162e3f550e1b3e6c59f1ccd3e3ee81a0c393c3d5989f7f22e0622ebf547", size = 145873, upload-time = "2026-03-31T12:04:03.126Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/ba/36952acbc7ea2af3e45595b100b35bbb734fd66e93f557969a0062f15be4/mir_python-1.28.1.17-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:60e7716add779b8645dc0a7e3b306ba36a7dea2f6ba5d092e5eac859f3feece8", size = 1175101, upload-time = "2026-03-31T12:05:56.84Z" },
-    { url = "https://files.pythonhosted.org/packages/30/99/8cde60b9cdcbcd4fad9e999804b0192707ca41eaf5fa042d55464de6e112/mir_python-1.28.1.17-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:875ba1d55b4c16b3502da4fa642259c889e2eedc676140c244ef89841e5f7944", size = 1189717, upload-time = "2026-03-31T12:09:14.37Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a9/e6e5b34402223311551b992b516a86df46f9eb3a99e8a0436c256a89802c/mir_python-1.28.1.17-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:8df1352c6932b3d933e72cf34352910b9e184866f824abb115cffd2deb300428", size = 141716, upload-time = "2026-03-31T12:17:30.943Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f0/f16bb400a1b7d74c9acde66dbf46ba206636e470757a29d9f2bdffd2a40d/mir_python-1.28.1.17-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:3f1fc87eb496a130a566d13496abd9706a4c596dc300dfd1d2baf9090f2f11a4", size = 144979, upload-time = "2026-03-31T12:19:55.734Z" },
-    { url = "https://files.pythonhosted.org/packages/87/8f/3a6407ccf5c4493db993c24f5651bf116a3a7e1bbc076c90e65f5cd05b61/mir_python-1.28.1.17-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:228b20f8f050de272a6462aeddc641bb1f049f767ef22f009cb49e968048cfd2", size = 1168122, upload-time = "2026-03-31T12:02:54.523Z" },
-    { url = "https://files.pythonhosted.org/packages/91/e1/ba16ba8920acbe39276b8d0abb692882c48c961151b210c5e414c1f32a25/mir_python-1.28.1.17-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:96911b6334f7e9ed4c40480b626dbf0a74e5789e3b94fbec7e3149e5bcc59d06", size = 1184197, upload-time = "2026-03-31T12:09:33.085Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/33/2dcd087ebad5e2fffc2b3866240902e17165a3e2268937d4353cfbc70d22/mir_python-1.28.1.17-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:0abc15337618fc5874fd97e6b6355b712ed59c5de839c2186fc00764b7dcf93f", size = 142699, upload-time = "2026-03-31T12:09:14.506Z" },
-    { url = "https://files.pythonhosted.org/packages/73/94/2035c32a7ec5cc654b471a100997b431d69a62b7f00beee2b90d3cbb8e87/mir_python-1.28.1.17-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:cd025cedc8f39c14dcc2869cf4d3f95f1513081cab62a15554fa38e4af0476b4", size = 145761, upload-time = "2026-03-31T12:04:07.258Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/6c/8d95ccc302cd5d3eb1ec0fc45457850cd69c8a6e0e0bde74aaff0ff2a499/mir_python-1.28.1.17-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:100dcca136732035c6f715f6ab8fbca98101ca5962a204bfb5c81f6a6a1a277a", size = 1169043, upload-time = "2026-03-31T12:04:36.051Z" },
-    { url = "https://files.pythonhosted.org/packages/96/d9/a3a933c3625700533f7cb0dc100cfdaa150e2ba90cb4d86eaf8bc8b6280c/mir_python-1.28.1.17-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ebf5b4ec1da7b028b693d09a789d6eb917e460dd07d7c629161893a6445dc7c6", size = 1180948, upload-time = "2026-03-31T12:09:46.724Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4a/f5ce941be7db958e6d3a3b9e63bbb3c1e4c08bea77852ff1c2152498de46/mir_python-1.29.0.21-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:5958bda598cc8af6beed4021407042603a9d4e5d215a40fffd0c29aae34e210d", size = 125476, upload-time = "2026-06-25T14:50:17.562Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/7d/a6ce460075e8395f3b017d9a33c1381f34caea6481e38365f01bb22b752c/mir_python-1.29.0.21-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:037eaaef52804c047e375aa83b1eff26aaa6c5e8c4af47290b1b68ac6b951406", size = 128519, upload-time = "2026-06-25T14:39:20.69Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/7827d331e962ff757c11d4911f80252502576b8cf22b4e45fe449447dc4b/mir_python-1.29.0.21-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:b33f877961292b2d59e13223ffb00c330d0fceb3e8374cfae9975e72587d68be", size = 118308, upload-time = "2026-06-25T14:35:19.381Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d8/7e45629b8816204778e092aea4782555b5b6d022c6264871ab8dc1e51799/mir_python-1.29.0.21-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:17408d9f17b3b566540ea116637e485b43ccec34acd72337ebc2f3bfe868d2c4", size = 121020, upload-time = "2026-06-25T14:35:34.668Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/57affaf98168b4fe6baa667f5b9e30a7189c312b5603ffcfd50a6bae4371/mir_python-1.29.0.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:5c405ba1836a13d8a7e61f72df93bfac637fd0a070aedb0c2235e525d97d1e68", size = 125873, upload-time = "2026-06-25T15:08:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f5/3a374341976952937f78c5e8fa437413a66d5c4e4f2daaa54023be0562c3/mir_python-1.29.0.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:391879074894800fd770c85748901cc93a1e7d2ec67d660ae0832a683be12f9a", size = 130600, upload-time = "2026-06-25T15:20:08.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/90/304ba78af7a64ee6123bac83b62ee9de6e75f8ca07286b8ceb7d672b8d59/mir_python-1.29.0.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e9dc04f558ec4b7f612888cd349a0ef866b9ae2fe802bcfce19c0133f7e39d74", size = 121244, upload-time = "2026-06-25T14:36:19.15Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/03d60923110e18a563fc875a346e86736c445c2c15960ae0cfeeeab38449/mir_python-1.29.0.21-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3be55256ae6845ba6c9c2403dbe9f4a7d6c24617e3032963f5dcf2e771769dee", size = 124384, upload-time = "2026-06-25T14:36:00.651Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d8/6a01aa7b582b8e99b5e5f8eb2f7062bd5a57816cc1e2d48cfc25a87f666a/mir_python-1.29.0.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:a39819091d1cd2795c401754800a6d9f81345c1a36164403d42d78bcdf14e7a9", size = 125296, upload-time = "2026-06-25T15:04:04.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/40/10acd808e51ba73a63614ca59e30d13696bd52ec31fad6e7460986003d6a/mir_python-1.29.0.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:e5d0c48d203884db81b6a755feff032ff592abf049a14fd7c110bb8ccc1f226a", size = 129808, upload-time = "2026-06-25T14:40:20.072Z" },
+    { url = "https://files.pythonhosted.org/packages/12/36/e5ef1d56cf5187a66368572c3a0f85a1d25f2a6496649828331d061d7093/mir_python-1.29.0.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f44fdc895eb5d2af8891df3d93848ece259eebfb8579b403cc66b8e34fe593b5", size = 120965, upload-time = "2026-06-25T14:33:16.163Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/106d819290226aa56ac99359e4a8875e9d084c0f05478d6aed3fd56e87f0/mir_python-1.29.0.21-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2f1e2dbdc06e545bd784aa176ae11a9b65b0a6bf6f3bf0171156a2b169267b15", size = 124143, upload-time = "2026-06-25T14:35:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/39/52/7c6c1831786a3cda8c924a8973e43775f23b8ddbf27451e585cdc94fd1fb/mir_python-1.29.0.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:e13ee30381943426434af73875d753b1ded6612928f62d9473e94841c72cf64e", size = 126541, upload-time = "2026-06-25T14:35:31.224Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b1/3e1e850dcb7e4f307e6296ac9d14602b0b6df304066050f0537af57ff7db/mir_python-1.29.0.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:2d07c8448492bd1113070e333f5bead2449da0bbea169ee3e25683e254df266f", size = 130285, upload-time = "2026-06-25T14:59:25.541Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ae/faec83302748c96110083148d26de544f52c9c6ee132670702fe63d0fadf/mir_python-1.29.0.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f8d4e04b6ddb6e74fbe67d9d104d05c7539c1b97a3a6f75e6a7a03bb06a46024", size = 121824, upload-time = "2026-06-25T14:35:00.872Z" },
+    { url = "https://files.pythonhosted.org/packages/51/28/4bda279c2fee799c3602ff2cf462155edb8bd6c817edeca5bf5088709a48/mir_python-1.29.0.21-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:99c790ba19c6f47c241d7337e2338c82ad9ce257f240f8bcd32268f842b91d93", size = 124096, upload-time = "2026-06-25T14:35:37.655Z" },
 ]
 
 [[package]]
 name = "mirlib"
-version = "1.28.1.17"
+version = "1.29.0.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "atlaslib-ecmwf" },
@@ -2500,22 +2504,22 @@ dependencies = [
     { name = "eckitlib" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/c0/2e848822efd1b8ae2bffd717ed85be652b307dfee9f4c96086bc76130008/mirlib-1.28.1.17-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:72409c5b48ecff83c69b26533fd3616fa8f6082b746e62da84476b74309e43bd", size = 1839752, upload-time = "2026-03-31T11:58:45.427Z" },
-    { url = "https://files.pythonhosted.org/packages/62/1c/460d83212f613c2cab5523ffad70619ef612eaffaff85bb3d4bc02314098/mirlib-1.28.1.17-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:ccf4a220354bcd4c5b42b6ba871b28127dca13acff8ae252052eb2e0b6dfd7e2", size = 1941921, upload-time = "2026-03-31T12:21:01.732Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ef/aebcf0f4c499320c1cdf8238f77b1cae10fafe31f418048be9eb3092fb42/mirlib-1.28.1.17-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5bc387c3027b787a2e64024420b72e7aa6822693495d97e4d790012a8c352221", size = 2443710, upload-time = "2026-03-31T12:06:04.961Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/96/2864b9d8146d3c77ae0f052a7a941d09664ad071361e70d43d5c3fb04314/mirlib-1.28.1.17-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:9dc27132c9551cdd7cdf9810799c142c55ce3cf944717b9233487405ca19cc01", size = 2418514, upload-time = "2026-03-31T12:08:52.637Z" },
-    { url = "https://files.pythonhosted.org/packages/66/54/3a2c3d493ef6a98db866451cacee8170a77f84944db68fa6c86a30b9ea82/mirlib-1.28.1.17-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:4a6248531df486cb646a383746a592484b60cda83a1b10ca1c8f4bcd3226b66b", size = 1839751, upload-time = "2026-03-31T11:57:51.949Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/8c/58bad9940ec859c420379b046c88cfb2bb820d6ca647ececfc70a2c24336/mirlib-1.28.1.17-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:db89c8f8a1bd2e6616c72e48a8a57efa6b638b35e5c7139d3434104ff3560d44", size = 1941919, upload-time = "2026-03-31T12:04:05.904Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/e7/55e13bdc9bf38c87c793f161f48dcf2cb714998741f0c3f080134f056e4c/mirlib-1.28.1.17-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c57c9bfe35fd528cfb92ca677135ff4b398efe3a603657fe4e8dc5a2201a149e", size = 2443711, upload-time = "2026-03-31T12:05:53.184Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/16/a3de7875d89f9a651f6e039b7c4ad36b60bb2b21385bdad0888b5fc0339a/mirlib-1.28.1.17-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:cc72c053c5df5e185d2477d4cc668937ca80aa816d5d7a901445d30c1808c912", size = 2418517, upload-time = "2026-03-31T12:09:10.017Z" },
-    { url = "https://files.pythonhosted.org/packages/64/3e/1291829a41f637d2610a976c9a0fb4eabf83990618ae308b71b5db4c8d1f/mirlib-1.28.1.17-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:9c0701452e65f3abf47c5bae1b1614c8cabf5a92f47a482decf9f1f99c31aa22", size = 1839754, upload-time = "2026-03-31T12:17:33.318Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/a7/e3b2edaf62de8503dd1374ccf56e67422711286a862c49b26f88d43a85fc/mirlib-1.28.1.17-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:3d8b179c34c04a2875e4d072200055de7f7ba9984e7567d996cdbea978d6c1b0", size = 1941918, upload-time = "2026-03-31T12:19:58.592Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ee/ffd184b01020c2067769b6f99742020e4807dbe9fbc5f2f159eaf8112aaf/mirlib-1.28.1.17-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:6e19a0038bd682098ad5db593e6c0cc6fbbd90262fce852241ac773174e0a83b", size = 2443709, upload-time = "2026-03-31T12:02:52.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/b9/f4bba4e330c87d8576b0d315893c4de52fc962a686cead66f5636fa912ec/mirlib-1.28.1.17-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:79c403531b155d8d6715f400da7a6ffa7899f11b9c7311a348def9ec36e9f7fa", size = 2418515, upload-time = "2026-03-31T12:09:29.798Z" },
-    { url = "https://files.pythonhosted.org/packages/06/ee/18dcc61d6b64e278077520875c26e2c5ef0b63ba97e36b43b4997b8e61a6/mirlib-1.28.1.17-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:2ba013d777f63c19c8187671e5f83d3fb144edc6091522439c5eae8086273ae5", size = 1839755, upload-time = "2026-03-31T12:09:18.646Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/fe/fc933fa54fb2bdc5718f6fadaa19e44f6c899a8a06ee94fd30266a057214/mirlib-1.28.1.17-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7ad3356f460260999bd60d5695c1f0f4a45f67fa71def55e6423c0153d88cb61", size = 1941920, upload-time = "2026-03-31T12:04:10.027Z" },
-    { url = "https://files.pythonhosted.org/packages/88/18/b4372bba8c51fdfc23c8bcc71b8b0ad0c1efec86a2a9ce6a9d8696023ef2/mirlib-1.28.1.17-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:d46ff54f4217aacdec7e2a0c18f248c78d6a89b7f514768d990a5b773a8afa9f", size = 2443710, upload-time = "2026-03-31T12:04:34.013Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/a5/1ece3034568609a463f957b1ee61a9fc1e24d34c64d7423c4b8e39b52561/mirlib-1.28.1.17-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:99227ae757c3e8038f64ac02b9c4c1e1d0dab8c3ecb8cd07a5efb4964fa8db2f", size = 2418518, upload-time = "2026-03-31T12:09:42.812Z" },
+    { url = "https://files.pythonhosted.org/packages/45/c5/0d10af6667266e39472fdfbd2a6f58864d3a075439ab25f908ece90c9fa8/mirlib-1.29.0.21-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:54f41cf28d53148cf2e7d67666a672a1a03d81a5c96b2e059a037daa25951894", size = 1843730, upload-time = "2026-06-25T14:50:20.213Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/36/65384d0e56b90362a2621c5b38076108dded9b9fab6af922b239abedddff/mirlib-1.29.0.21-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:d8bed80e4b91812ddf476095041975ad84c9cf06fa1c29b877c33fd55b16f286", size = 1939340, upload-time = "2026-06-25T14:39:23.281Z" },
+    { url = "https://files.pythonhosted.org/packages/94/15/7880300d914b422a7e23ad056db0b2ffb2e71a1d770aa4d4bf700bf44d85/mirlib-1.29.0.21-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:dac25db06eb044c4aea101be5bfc938b8d15113200cd37d0ff042467de0de8bb", size = 2451013, upload-time = "2026-06-25T14:35:17.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0b/3fae67c84bdb27af1d039b5d825f8f5acaba8b2a1e3f72d5ea292ee992ae/mirlib-1.29.0.21-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:2b1601190a7b1f4af2f14aebbeb5b6349315d26a99e1e1009e869b3d0bb0cffb", size = 2425273, upload-time = "2026-06-25T14:35:31.423Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/7e85e5db10c676c0f38da1a4948b2b1ca757ad208b23d250d260d41aeb7e/mirlib-1.29.0.21-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:ba7ecd1fa4f9421c93b3b1950fd6e3a80fb397b383c4351ddd2a2d219f980133", size = 1843724, upload-time = "2026-06-25T15:08:06.274Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/d35cef505db8f650273a478538b7ad1f5e6390a1a17f61a1f98860f501b6/mirlib-1.29.0.21-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:b6a75f1411da3c2eee96b5ec1946f9260f232fce7002932533346d70ff9ce581", size = 1939338, upload-time = "2026-06-25T15:20:10.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c3/a9debac769dd3793036f1fb4151795e4773f2ee663258a4e2ecf8dff0835/mirlib-1.29.0.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:925d982290714ab8b154ac6b525ce9b09b23656f8755a84fabf66350762db660", size = 2451012, upload-time = "2026-06-25T14:36:16.857Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6b/35dc8cb472ed7c5df6d663544a58979a547905db72309eb0cea53b532487/mirlib-1.29.0.21-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dd0f3c3829f54c4051ac5f0a3aee36166eafd88361e469ef66a7c785b77250cb", size = 2425272, upload-time = "2026-06-25T14:35:57.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/92/30d0ffc841cdc269b395eb0155f31b8e751a70c35278179ce71f91e6db6d/mirlib-1.29.0.21-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:48cf74cd360f7e186dcba84c99a56ad6d2935a4973b2f708a442f6dd103b4cce", size = 1843726, upload-time = "2026-06-25T15:04:07.352Z" },
+    { url = "https://files.pythonhosted.org/packages/04/22/75a3f175384a5d988c377b411fe430fa4be19854a1e7d4005ab8c64afd02/mirlib-1.29.0.21-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:b7a25ece3e8cd0ace1c9d87e0f5b1354bdd98404c5455ec887e0bfa86cdf54a0", size = 1940018, upload-time = "2026-06-25T14:40:22.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e4/84442fbc3560cc727a47849dfe25abce494b342e026960366ada8ba8e2c5/mirlib-1.29.0.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:451d57fcf88769c0f32b2bb4a4dcf0024b7f08b2ff24ef3e099640ad40231141", size = 2451009, upload-time = "2026-06-25T14:33:13.96Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d4/e8fd624cfd977d839d15c6374d4923cf0a1e95ed6d2abcb9134096925a75/mirlib-1.29.0.21-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6650cbb11fd6cb74b1730e6ed29a12da6e74b6fdd7c9ae2275de9654b3593854", size = 2425274, upload-time = "2026-06-25T14:35:46.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/25/6a58d1e47ebfd54547959cf830d02fc7d2acd72cc6f885f89996929587d1/mirlib-1.29.0.21-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:5216c8bc036481bea4f95e27a480caa342ffe013a55a88509a48827be782e92c", size = 1843730, upload-time = "2026-06-25T14:35:33.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ba/f25ca34d3a5e00d42a8acd5d55b1cf4eecd9b688b5c9d2bbe21221b9cae2/mirlib-1.29.0.21-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:3f2987331e257db369008fbe9ff30fa14c2854f0f9e3e4d1604bfa1714f26959", size = 1939341, upload-time = "2026-06-25T14:59:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/cd/ed761579aac7cc6a095c61f4e8df2372df5848bb6643e8671bb60e743ce1/mirlib-1.29.0.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:928d34a9cdb9dbce89ddbbf7883242d3f5bb2d49a1f3fedf2bd3b8b8a5cf6c49", size = 2451011, upload-time = "2026-06-25T14:34:58.577Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/ae00bc701ae6be4cb26ec6913b0b1c574c4c760d8db2240aa15dff2dca16/mirlib-1.29.0.21-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:09b38bbc4c3190cd110338ab2223f9247e0284f7d558f6eb0d588bdfa0c1ed87", size = 2425278, upload-time = "2026-06-25T14:35:33.8Z" },
 ]
 
 [[package]]

--- a/workflow/rules/data.smk
+++ b/workflow/rules/data.smk
@@ -2,36 +2,3 @@ from pathlib import Path
 
 
 include: "common.smk"
-
-
-# Grid-definition files required by earthkit/eckit to decode the ICON-CH grids.
-# Automatic download/caching of these is currently broken (see README), so we
-# fetch them into eckit's default geo grid cache under $HOME, where it finds
-# them without any ECKIT_GEO_CACHE wiring. The output file names are the cache
-# keys eckit computes for each grid.
-ECKIT_GEO_GRID_DIR = Path.home() / ".local/share/eckit/geo/grid/icon"
-ECKIT_ICON_CH1_URL = (
-    "https://sites.ecmwf.int/repository/eckit/geo/grid/icon-ch/icon-ch1-c.ek"
-)
-ECKIT_ICON_CH2_URL = (
-    "https://sites.ecmwf.int/repository/eckit/geo/grid/icon-ch/icon-ch2-c.ek"
-)
-
-
-rule data_download_eckit_geo_grids:
-    output:
-        ch1=ECKIT_GEO_GRID_DIR
-        / "17643da2574959b644d254a3cd6e2bc0-b0699f374c63d05028c18c12f80a48f4.ek",
-        ch2=ECKIT_GEO_GRID_DIR
-        / "bbbd5a09855499243c7a4aa4c8762920-67adabf5c0cff041ebaafa61a3bda267.ek",
-    log:
-        OUT_ROOT / "logs/data_download_eckit_geo_grids/download.log",
-    localrule: True
-    shell:
-        """
-        (
-            set -euo pipefail
-            curl -fL {ECKIT_ICON_CH1_URL:q} -o {output.ch1:q}
-            curl -fL {ECKIT_ICON_CH2_URL:q} -o {output.ch2:q}
-        ) >{log} 2>&1
-        """

--- a/workflow/rules/plot.smk
+++ b/workflow/rules/plot.smk
@@ -28,7 +28,6 @@ rule plot_meteogram:
         script="workflow/scripts/plot_meteogram.py",
         inference_okfile=rules.inference_execute.output.okfile,
         truth_dep=truth_file_dep,
-        eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
         expand(
             OUT_ROOT
@@ -93,7 +92,6 @@ rule plot_forecast_frame:
     input:
         script="workflow/scripts/plot_forecast_frame.py",
         inference_okfile=rules.inference_execute.output.okfile,
-        eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
         expand(
             OUT_ROOT

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -16,7 +16,6 @@ rule verification_metrics_baseline:
         script="workflow/scripts/verification_metrics.py",
         forecast=lambda wc: BASELINE_CONFIGS[wc.baseline_id]["root"],
         truth_dep=truth_file_dep,
-        eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
         OUT_ROOT / f"data/baselines/{{baseline_id}}/{{init_time}}/verif_{TRUTH_HASH}.nc",
     log:
@@ -65,7 +64,6 @@ rule verification_metrics:
         script="workflow/scripts/verification_metrics.py",
         inference_okfile=rules.inference_execute.output.okfile,
         truth_dep=truth_file_dep,
-        eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
         OUT_ROOT / f"data/runs/{{run_id}}/{{init_time}}/verif_{TRUTH_HASH}.nc",
     log:
@@ -233,7 +231,6 @@ rule verification_scoremaps_baseline:
         script="workflow/scripts/verification_scoremaps.py",
         forecast=lambda wc: BASELINE_CONFIGS[wc.baseline_id]["root"],
         truth=config["truth"]["root"],
-        eckit_grids=rules.data_download_eckit_geo_grids.output,
     output:
         OUT_ROOT
         / f"data/baselines/{{baseline_id}}/scoremaps/{{param}}_{{leadtime}}_{TRUTH_HASH}.nc",


### PR DESCRIPTION
This PR completes the recent update of earthkit dependencies introduced in #206 by updating the lock file as well.