### PR TITLE
Fail fast if jretrieve credentials are missing

### DIFF
--- a/src/data_input/jretrieve.py
+++ b/src/data_input/jretrieve.py
@@ -59,6 +59,55 @@ def _build_env(stage: str) -> dict[str, str]:
     return env
 
 
+def _check_credentials(conf_dir: Path) -> str | None:
+    """Return a descriptive error string if jretrieve credentials are missing."""
+    client_id = os.environ.get("JRETRIEVE_CLIENT_ID")
+    client_secret = os.environ.get("JRETRIEVE_CLIENT_SECRET")
+
+    dotenv_path = conf_dir / ".env"
+    dotenv_exists = dotenv_path.is_file()
+
+    if not (client_id and client_secret) and dotenv_exists:
+        dotenv: dict[str, str] = {}
+        try:
+            with open(dotenv_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, _, value = line.partition("=")
+                    dotenv[key.strip()] = value.strip().strip('"').strip("'")
+        except OSError:
+            pass
+        client_id = client_id or dotenv.get("JRETRIEVE_CLIENT_ID")
+        client_secret = client_secret or dotenv.get("JRETRIEVE_CLIENT_SECRET")
+
+    if client_id and client_secret:
+        return None
+
+    missing = [
+        name
+        for name, val in (
+            ("JRETRIEVE_CLIENT_ID", client_id),
+            ("JRETRIEVE_CLIENT_SECRET", client_secret),
+        )
+        if not val
+    ]
+    lines = [
+        f"Missing jretrieve credentials: {', '.join(missing)}.",
+        "Credentials must be supplied in one of two ways:",
+        f"  1. Set {' and '.join(missing)} as environment variables.",
+        f"  2. Add them to {dotenv_path}",
+    ]
+    if dotenv_exists:
+        lines.append(
+            f"     (.env file exists but does not contain {' or '.join(missing)})"
+        )
+    else:
+        lines.append("     (.env file not found — create it with the missing keys)")
+    return "\n".join(lines)
+
+
 def check_prerequisites(stage: str = "prod") -> None:
     """Fail-fast validation that the jretrievedwh environment is usable.
 
@@ -73,9 +122,13 @@ def check_prerequisites(stage: str = "prod") -> None:
         _resolve_binary()
     except JretrieveError as e:
         problems.append(str(e))
-    conf_path = Path(__file__).parents[2] / ".jretrievedwh-conf.prod.py"
+    conf_dir = Path(__file__).parents[2]
+    conf_path = conf_dir / ".jretrievedwh-conf.prod.py"
     if not conf_path.is_file():
         problems.append(f"jretrieve conf file not found: {conf_path}")
+    cred_problem = _check_credentials(conf_dir)
+    if cred_problem:
+        problems.append(cred_problem)
     if problems:
         raise JretrieveError(
             "jretrievedwh prerequisites not met:\n  - " + "\n  - ".join(problems)

--- a/tests/unit/test_jretrieve.py
+++ b/tests/unit/test_jretrieve.py
@@ -58,12 +58,16 @@ def test_check_prerequisites_ok(monkeypatch, tmp_path):
     conf.write_text("# conf\n")
     monkeypatch.setattr(jr.shutil, "which", lambda name: "/opt/bin/jretrievedwh.py")
     monkeypatch.setenv("OPR_HOME", str(tmp_path))
+    monkeypatch.setenv("JRETRIEVE_CLIENT_ID", "dummy-id")
+    monkeypatch.setenv("JRETRIEVE_CLIENT_SECRET", "dummy-secret")
     jr.check_prerequisites("prod")  # should not raise
 
 
 def test_check_prerequisites_missing_binary(monkeypatch):
     monkeypatch.setattr(jr.shutil, "which", lambda name: None)
     monkeypatch.setattr(jr.os.path, "isfile", lambda p: False)
+    monkeypatch.setenv("JRETRIEVE_CLIENT_ID", "dummy-id")
+    monkeypatch.setenv("JRETRIEVE_CLIENT_SECRET", "dummy-secret")
     with pytest.raises(jr.JretrieveError, match=r"\$PATH"):
         jr.check_prerequisites("prod")
 
@@ -72,12 +76,58 @@ def test_check_prerequisites_aggregates_all_problems(monkeypatch):
     monkeypatch.setattr(jr.shutil, "which", lambda name: None)
     monkeypatch.setattr(jr.os.path, "isfile", lambda p: False)
     monkeypatch.setattr(Path, "is_file", lambda self: False)
+    monkeypatch.setenv("JRETRIEVE_CLIENT_ID", "dummy-id")
+    monkeypatch.setenv("JRETRIEVE_CLIENT_SECRET", "dummy-secret")
     with pytest.raises(jr.JretrieveError) as exc:
         jr.check_prerequisites("prod")
     msg = str(exc.value)
     assert (
         "$PATH" in msg and "conf file not found" in msg
     )  # both reported, not just the first
+
+
+def test_check_credentials_ok_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("JRETRIEVE_CLIENT_ID", "dummy-id")
+    monkeypatch.setenv("JRETRIEVE_CLIENT_SECRET", "dummy-secret")
+    assert jr._check_credentials(tmp_path) is None
+
+
+def test_check_credentials_ok_from_dotenv(monkeypatch, tmp_path):
+    monkeypatch.delenv("JRETRIEVE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("JRETRIEVE_CLIENT_SECRET", raising=False)
+    (tmp_path / ".env").write_text(
+        "JRETRIEVE_CLIENT_ID=id-from-file\nJRETRIEVE_CLIENT_SECRET=secret-from-file\n"
+    )
+    assert jr._check_credentials(tmp_path) is None
+
+
+def test_check_credentials_missing_both_no_dotenv(monkeypatch, tmp_path):
+    monkeypatch.delenv("JRETRIEVE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("JRETRIEVE_CLIENT_SECRET", raising=False)
+    msg = jr._check_credentials(tmp_path)
+    assert msg is not None
+    assert "JRETRIEVE_CLIENT_ID" in msg
+    assert "JRETRIEVE_CLIENT_SECRET" in msg
+    assert ".env file not found" in msg
+
+
+def test_check_credentials_dotenv_exists_but_incomplete(monkeypatch, tmp_path):
+    monkeypatch.delenv("JRETRIEVE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("JRETRIEVE_CLIENT_SECRET", raising=False)
+    (tmp_path / ".env").write_text("JRETRIEVE_CLIENT_ID=id-from-file\n")
+    msg = jr._check_credentials(tmp_path)
+    assert msg is not None
+    assert "JRETRIEVE_CLIENT_SECRET" in msg
+    assert ".env file exists" in msg
+
+
+def test_check_prerequisites_missing_credentials(monkeypatch):
+    monkeypatch.setattr(jr.shutil, "which", lambda name: "/opt/bin/jretrievedwh.py")
+    monkeypatch.setattr(Path, "is_file", lambda self: str(self).endswith(".prod.py"))
+    monkeypatch.delenv("JRETRIEVE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("JRETRIEVE_CLIENT_SECRET", raising=False)
+    with pytest.raises(jr.JretrieveError, match="JRETRIEVE_CLIENT"):
+        jr.check_prerequisites("prod")
 
 
 def _sample_meta():


### PR DESCRIPTION
This PR implements checks on jretrieve credential to fail fast and with an informative error message if jretrieve credentials are missing and verificiation is performed against station data.

### Summary of changes
check jretrieve credentials as part of check_prerequisites function