### PR TITLE
Allow selection of stations out of switzerland

### DIFF
--- a/src/data_input/jretrieve.py
+++ b/src/data_input/jretrieve.py
@@ -299,7 +299,7 @@ def fetch_data(
     increment_minutes=60,
     seq_type="surface",
     stage="prod",
-    use_limitation: int | None = None,
+    use_limitation: int = 40,
     timeout_s=600,
 ) -> pd.DataFrame:
     """Fetch observation data; columns: station (int), termin (YYYYMMDDhhmmss),
@@ -318,8 +318,7 @@ def fetch_data(
         "csv",
         *_stations_to_argv(stations),
     ]
-    if use_limitation is not None:
-        argv += ["--use-limitation", str(use_limitation)]
+    argv += ["--use-limitation", str(use_limitation)]
     LOG.info("jretrieve data: %s", " ".join(argv))
     return _parse_csv(_run_with_retry(argv, env=_build_env(stage), timeout_s=timeout_s))
 

--- a/src/data_input/jretrieve.py
+++ b/src/data_input/jretrieve.py
@@ -299,6 +299,7 @@ def fetch_data(
     increment_minutes=60,
     seq_type="surface",
     stage="prod",
+    use_limitation: int | None = None,
     timeout_s=600,
 ) -> pd.DataFrame:
     """Fetch observation data; columns: station (int), termin (YYYYMMDDhhmmss),
@@ -317,6 +318,8 @@ def fetch_data(
         "csv",
         *_stations_to_argv(stations),
     ]
+    if use_limitation is not None:
+        argv += ["--use-limitation", str(use_limitation)]
     LOG.info("jretrieve data: %s", " ".join(argv))
     return _parse_csv(_run_with_retry(argv, env=_build_env(stage), timeout_s=timeout_s))
 


### PR DESCRIPTION
## Summary

This PR adds an optional `use_limitation` parameter to `fetch_data` in `jretrieve.py`. This allows to retrieve data from partner stations located out of Switzerland.

## Changes

- Add an optional `use_limitation` argument to `fetch_data`.
- Forward `--use-limitation <value>` to the `jretrievedwh.py` CLI when the parameter is provided, allowing station data to be filtered according to data usage rights.
- Preserve the current behaviour when `use_limitation` is omitted (`None`), allowing the CLI default value (`20`) to be used.

## Notes

- `use_limitation` is **not** added to `fetch_meta`, as the underlying meta-info endpoint does not support this option.
- additional information: https://service.meteoswiss.ch/jretrieve/api/v1/surface/help