### PR TITLE
Add integration test for configs

### DIFF
--- a/ci/cscs.yml
+++ b/ci/cscs.yml
@@ -40,7 +40,7 @@ integration_test_job:
       UV_HOME="$VENV_DIR" uv sync
       source "$VENV_DIR/bin/activate"
   script:
-    - pytest tests/integration -m longtest
+    - pytest tests/integration -m heavytest
   variables:
     # Explicitly request more time from Slurm, so that the long tests can complete.
     SLURM_TIMELIMIT: "10:00:00"

--- a/ci/cscs.yml
+++ b/ci/cscs.yml
@@ -43,4 +43,4 @@ integration_test_job:
     - pytest tests/integration -m longtest
   variables:
     # Explicitly request more time from Slurm, so that the long tests can complete.
-    SLURM_TIMELIMIT: "01:00:00"
+    SLURM_TIMELIMIT: "10:00:00"

--- a/resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper-test.yaml
+++ b/resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper-test.yaml
@@ -1,0 +1,81 @@
+lead_time: 12h
+write_initial_state: true
+allow_nans: true
+
+env:
+  ANEMOI_INFERENCE_NUM_CHUNKS: 8 # OOM error if not set
+
+# inputs
+input:
+  test:
+    use_original_paths: true
+
+post_processors:
+  - accumulate_from_start_of_forecast: # accumulate tp from start of forecast
+      accumulations:
+        - tp
+  - forward_transform_filter:
+      rescale:
+        scale: 1000 # convert units from m to kg m-2
+        offset: 0
+        param: tp
+
+output:
+  tee:
+    - grib:
+        path: grib/{date}{time:04}_{step:03}.grib
+        encoding:
+          typeOfGeneratingProcess: 2
+          centre: lssw
+        templates:
+          samples: resources/templates_index_icon.yaml
+        post_processors:
+          - extract_mask: # removes global points
+              mask: "lam_0/cutout_mask"
+              as_slice: true
+    - grib:
+        path: grib/ifs-{date}{time:04}_{step:03}.grib
+        encoding:
+          typeOfGeneratingProcess: 2
+          centre: ecmf
+        templates:
+          samples: resources/templates_index_ifs.yaml
+        post_processors:
+        - extract_mask: # removes lam points
+            mask: "lam_0/cutout_mask"
+            as_slice: true
+            inverse: true
+        - assign_mask: # fill local/global overlapping points with nan
+            mask: "global/cutout_mask"
+        modifiers:
+          - patches:
+            - variable:
+                U_10M: {"param": 165, "shortName": "10u"}
+                10u: {"param": 165, "shortName": "10u"}
+                V_10M: {"param": 166, "shortName": "10v"}
+                10v: {"param": 166, "shortName": "10v"}
+                TD_2M: {"param": 168, "shortName": "2d"}
+                2d: {"param": 168, "shortName": "2d"}
+                T_2M: {"param": 167, "shortName": "2t"}
+                2t: {"param": 167, "shortName": "2t"}
+                FR_LAND: {"param": 172, "shortName": "lsm"}
+                lsm: {"param": 172, "shortName": "lsm"}
+                PMSL: {"param": 151, "shortName": "msl"}
+                msl: {"param": 151, "shortName": "msl"}
+                PS: {"param": 134, "shortName": "sp"}
+                sp: {"param": 134, "shortName": "sp"}
+                SSO_SIGMA: {"param": 163, "shortName": "slor"}
+                slor: {"param": 163, "shortName": "slor"}
+                SSO_STDH: {"param": 160, "shortName": "sdor"}
+                sdor: {"param": 160, "shortName": "sdor"}
+                TOT_PREC: {"param": 228, "shortName": "tp"}
+                tp: {"param": 228, "shortName": "tp"}
+                z: {"param": 129, "shortName": "z"}
+                "^q_(\\d+)$": {"param": 133, "shortName": "q"}
+                "^t_(\\d+)$": {"param": 130, "shortName": "t"}
+                "^u_(\\d+)$": {"param": 131, "shortName": "u"}
+                "^v_(\\d+)$": {"param": 132, "shortName": "v"}
+                "^w_(\\d+)$": {"param": 135, "shortName": "w"}
+                "^z_(\\d+)$": {"param": 129, "shortName": "z"}
+
+patch_metadata: resources/sgm-multidataset-ich1-oper-patch.yaml

--- a/tests/integration/configs/varda-single-1.0.yaml
+++ b/tests/integration/configs/varda-single-1.0.yaml
@@ -1,0 +1,131 @@
+# yaml-language-server: $schema=../../../workflow/tools/config.schema.json
+description: |
+  Evaluate skill of Varda-single-1.0 against ground observations.
+
+config_label: varda-single-1.0
+
+dates:
+  - 2025-03-01T00:00
+  - 2025-03-02T00:00
+
+runs:
+  - temporal_downscaler:
+      checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-2-interpolator/versions/3
+      label: Varda-single-1.0
+      steps: 0/12/1
+      config: resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml
+      extra_requirements:
+        - anemoi-datasets==0.5.35
+      forecaster:
+        checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-1-forecaster/versions/4
+        config: resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper-test.yaml
+        steps: 0/12/6
+  - baseline:
+      label: INCA
+      root: /store_new/mch/msclim/INCA
+      steps: 0/6/1
+  - baseline:
+      label: ICON-CH2-CTRL
+      root: /store_new/mch/msopr/osm/ICON-CH2-EPS
+      steps: 0/12/1
+  - baseline:
+      label: ICON-CH1-CTRL
+      root: /store_new/mch/msopr/osm/ICON-CH1-EPS
+      steps: 0/12/1
+
+truth:
+  label: SwissMetNet
+  root: jretrievedwh:1,2
+  # To verify against SwissMetNet observations from the DWH via jretrievedwh,
+  # set instead (requires jretrievedwh.py on $PATH and $OPR_HOME set):
+  # Other selectors: root: jretrievedwh:locations=ARO,KLO,LUG
+  #                  root: jretrievedwh:bbox=45.8,47.8,5.9,10.5
+  #                  append ;stage=devt to target a non-prod DWH stage
+
+experiment:
+  params:
+    - T_2M
+    - TD_2M
+    - SP_10M
+    - TOT_PREC1
+    - TOT_PREC6
+    - PMSL
+  stratification:
+    regions:
+      - mittelland
+      - berge
+      - alpennordseite
+      - alpensuedseite
+      - jura
+    root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
+  thresholds:
+    TOT_PREC1:
+      gt: [0.0, 0.1, 1, 5, 10]
+    TOT_PREC6:
+      gt: [0.0, 0.1, 5, 10, 20, 50]
+    SP_10M:
+      gt: [2.5, 5.0, 10.0]
+    T_2M:
+      lt: [273.15]
+      gt: [288.15, 298.15]
+  dashboard:
+    stratification:
+      # - region
+      # - init_hour
+      - season
+  scorecards:
+    enabled: true
+    sections:
+      nowcasting:
+        baseline: INCA
+        lead_times: "0/6/1"
+        stratification: region
+        variables:
+          - "U_10M:RMSE,R2,ETS"
+          - "V_10M:RMSE,R2,ETS"
+          - "T_2M:RMSE,R2,ETS"
+          - "TOT_PREC1:RMSE,R2,ETS"
+      short_range:
+        baseline: ICON-CH1-CTRL
+        lead_times: "6/12/6"
+        stratification: region
+        variables:
+          - "U_10M:RMSE,R2,ETS"
+          - "V_10M:RMSE,R2,ETS"
+          - "T_2M:RMSE,R2,ETS"
+          - "TOT_PREC6:RMSE,R2,ETS"
+  scoremaps:
+    enabled: false
+
+showcase:
+  params:
+    - T_2M
+    - SP_10M
+    - TOT_PREC1
+  meteograms:
+    enabled: false
+    stations: [JUN] #, COV, GOR, WFJ, SAE, SAM, DAV, ZER, ANT, VSBAS, BRT, LTB, GOS, CEV, BIA]
+  animations:
+    enabled: true
+    frames_per_second: 5
+    domains:
+      # - globe
+      - europe
+      # - alps
+      - icon-ch
+      - switzerland
+
+locations:
+  output_root: output/
+
+profile:
+  executor: slurm
+  global_resources:
+    gpus: 16
+  default_resources:
+    slurm_partition: "postproc"
+    cpus_per_task: 1
+    mem_mb_per_cpu: 1800
+    runtime: "1h"
+    gpus: 0
+  jobs: 50

--- a/tests/integration/test_configs.py
+++ b/tests/integration/test_configs.py
@@ -48,7 +48,7 @@ EXPECTED = {
 SEL = {"region": "all", "season": "all", "init_hour": -999}
 
 
-@pytest.mark.longtest
+@pytest.mark.heavytest
 @pytest.mark.parametrize("config_name", CONFIGS)
 def test_experiment_metrics(config_name):
     expected = EXPECTED[config_name]

--- a/tests/integration/test_configs.py
+++ b/tests/integration/test_configs.py
@@ -1,0 +1,81 @@
+import glob
+import subprocess
+from pathlib import Path
+
+import pytest
+import xarray as xr
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CONFIGS_DIR = Path(__file__).resolve().parent / "configs"
+
+# Configs to test — add or remove names here to control which runs are exercised.
+CONFIGS = [
+    "varda-single-1.0.yaml",
+]
+
+# Known-good metric values per config, captured from reference runs.
+# After running a config for the first time, read values with:
+#   ds = xr.open_dataset(glob.glob("output/data/runs/**/verif_aggregated_*.nc", recursive=True)[0])
+#   run_src = next(s for s in ds.coords["source"].values if not str(s).startswith("truth"))
+#   SEL = {"region": "all", "season": "all", "init_hour": -999}
+#   print(float(ds["T_2M.RMSE"].sel(source=run_src, **SEL).mean("step").values))
+# Values are step-averaged over the fully aggregated slice (region=all, season=all, init_hour=-999).
+EXPECTED = {
+    "varda-single-1.0.yaml": {
+        "T_2M.RMSE":      pytest.approx(1.613003, abs=1e-6),
+        "T_2M.BIAS":      pytest.approx(0.093322, abs=1e-6),
+        "T_2M.MAE":       pytest.approx(1.076129, abs=1e-6),
+        "T_2M.CORR":      pytest.approx(0.938171, abs=1e-6),
+        "TD_2M.RMSE":     pytest.approx(2.146990, abs=1e-6),
+        "TD_2M.BIAS":     pytest.approx(0.657801, abs=1e-6),
+        "TD_2M.MAE":      pytest.approx(1.379343, abs=1e-6),
+        "TD_2M.CORR":     pytest.approx(0.949576, abs=1e-6),
+        "SP_10M.RMSE":    pytest.approx(1.697493, abs=1e-6),
+        "SP_10M.BIAS":    pytest.approx(-0.404315, abs=1e-6),
+        "SP_10M.MAE":     pytest.approx(1.235294, abs=1e-6),
+        "SP_10M.CORR":    pytest.approx(0.680784, abs=1e-6),
+        "PMSL.RMSE":      pytest.approx(41.761943, abs=1e-6),
+        "PMSL.BIAS":      pytest.approx(5.627536, abs=1e-6),
+        "PMSL.MAE":       pytest.approx(32.933578, abs=1e-6),
+        "PMSL.CORR":      pytest.approx(0.928961, abs=1e-6),
+        "TOT_PREC6.RMSE": pytest.approx(0.450449, abs=1e-6),
+        "TOT_PREC6.BIAS": pytest.approx(0.077970, abs=1e-6),
+        "TOT_PREC6.MAE":  pytest.approx(0.112071, abs=1e-6),
+        "TOT_PREC6.CORR": pytest.approx(0.720550, abs=1e-6),
+    },
+}
+
+SEL = {"region": "all", "season": "all", "init_hour": -999}
+
+
+@pytest.mark.longtest
+@pytest.mark.parametrize("config_name", CONFIGS)
+def test_experiment_metrics(config_name):
+    expected = EXPECTED[config_name]
+
+    result = subprocess.run(
+        ["evalml", "experiment", str(CONFIGS_DIR / config_name)],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"evalml experiment failed for {config_name} (exit {result.returncode}).\n"
+        f"stdout:\n{result.stdout[-2000:]}\n"
+        f"stderr:\n{result.stderr[-2000:]}"
+    )
+
+    nc_files = glob.glob(
+        str(PROJECT_ROOT / "output/data/runs/**/verif_aggregated_*.nc"),
+        recursive=True,
+    )
+    assert nc_files, f"No verif_aggregated_*.nc found in output/data/runs/ for {config_name}"
+
+    ds = xr.open_dataset(nc_files[0])
+
+    run_source = next(
+        str(s) for s in ds.coords["source"].values if not str(s).startswith("truth")
+    )
+    for metric, expected_value in expected.items():
+        actual = float(ds[metric].sel(source=run_source, **SEL).mean("step").values)
+        assert actual == expected_value, f"{config_name} {metric}: got {actual}"


### PR DESCRIPTION
Adds an integration test that runs the full evalml experiment pipeline and asserts that key verification metrics match reference values from a known-good run.