### PR TITLE
Testing dashboard small

### DIFF
--- a/src/data_input/__init__.py
+++ b/src/data_input/__init__.py
@@ -1,8 +1,6 @@
 import json
 import logging
-import os
 import re
-import tempfile
 import urllib.request
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -176,15 +174,10 @@ def _fetch_icon_const_grib(model: str) -> Path:
             href = asset["href"]
             break
     LOG.info("Downloading %s constants to %s", model, cached)
-    # Unique-per-process tmp file: concurrent Snakemake rules can race here on a
-    # cold cache, and a shared tmp path means whichever process renames first
-    # leaves the other's `tmp.rename()` targeting an already-moved file.
-    fd, tmp_name = tempfile.mkstemp(dir=_ICON_CONST_CACHE, prefix=f"{asset_id}.")
-    os.close(fd)  # mkstemp's fd only reserves the unique name; urlretrieve writes by path
-    tmp = Path(tmp_name)
+    tmp = cached.with_suffix(".tmp")
     try:
         urllib.request.urlretrieve(href, tmp)
-        tmp.replace(cached)  # atomic; safe even if another process just wrote `cached`
+        tmp.rename(cached)
     except Exception:
         tmp.unlink(missing_ok=True)
         raise

--- a/src/data_input/__init__.py
+++ b/src/data_input/__init__.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import os
 import re
+import tempfile
 import urllib.request
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -174,10 +176,15 @@ def _fetch_icon_const_grib(model: str) -> Path:
             href = asset["href"]
             break
     LOG.info("Downloading %s constants to %s", model, cached)
-    tmp = cached.with_suffix(".tmp")
+    # Unique-per-process tmp file: concurrent Snakemake rules can race here on a
+    # cold cache, and a shared tmp path means whichever process renames first
+    # leaves the other's `tmp.rename()` targeting an already-moved file.
+    fd, tmp_name = tempfile.mkstemp(dir=_ICON_CONST_CACHE, prefix=f"{asset_id}.")
+    os.close(fd)  # mkstemp's fd only reserves the unique name; urlretrieve writes by path
+    tmp = Path(tmp_name)
     try:
         urllib.request.urlretrieve(href, tmp)
-        tmp.rename(cached)
+        tmp.replace(cached)  # atomic; safe even if another process just wrote `cached`
     except Exception:
         tmp.unlink(missing_ok=True)
         raise

--- a/tests/integration/configs/dashboard_small.yaml
+++ b/tests/integration/configs/dashboard_small.yaml
@@ -10,12 +10,12 @@ config_label: dashboard-test
 # must run real inference, so temporarily comment this line out, run
 # `evalml experiment <this config>`, then `evalml capture-fixture <this config>
 # <path>`, and restore it (see tests/integration/README.md).
-fixture_root: /scratch/mch/mmcgloho/evalml_test_fixtures/dashboard-small
+fixture_root: /store_new/mch/msopr/ml/evalml/test_fixtures/dashboard-small
 
 dates:
   - 2024-08-01T00:00
 
-runs:
+runs:`
   - temporal_downscaler:
       checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-2-interpolator/versions/3
       label: Varda-single-1.0

--- a/tests/integration/configs/dashboard_small.yaml
+++ b/tests/integration/configs/dashboard_small.yaml
@@ -15,7 +15,7 @@ fixture_root: /store_new/mch/msopr/ml/evalml/test_fixtures/dashboard-small
 dates:
   - 2024-08-01T00:00
 
-runs:`
+runs:
   - temporal_downscaler:
       checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-2-interpolator/versions/3
       label: Varda-single-1.0

--- a/tests/integration/configs/dashboard_small.yaml
+++ b/tests/integration/configs/dashboard_small.yaml
@@ -5,6 +5,13 @@ description: |
 
 config_label: dashboard-test
 
+# Always replay inference from this frozen fixture (no GPU / MLflow / sandbox
+# build); truth still comes live from the DWH. To (re)capture the fixture you
+# must run real inference, so temporarily comment this line out, run
+# `evalml experiment <this config>`, then `evalml capture-fixture <this config>
+# <path>`, and restore it (see tests/integration/README.md).
+#fixture_root: /scratch/mch/mmcgloho/evalml_test_fixtures/dashboard-small
+
 dates:
   - 2024-08-01T00:00
 

--- a/tests/integration/configs/dashboard_small.yaml
+++ b/tests/integration/configs/dashboard_small.yaml
@@ -1,0 +1,108 @@
+# yaml-language-server: $schema=../../../workflow/tools/config.schema.json
+description: |
+  Test the dashboard functionality on a minimal config. One reference date, short lead times,
+  animations disabled. Driven by tests/integration/test_dashboard_small.py.
+
+config_label: dashboard-test
+
+dates:
+  - 2024-08-01T00:00
+
+runs:
+  - temporal_downscaler:
+      checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-2-interpolator/versions/3
+      label: Varda-single-1.0
+      steps: 0/12/1
+      config: resources/inference/configs/sgm-temporal-downscaler-global_trimedge_multi.yaml
+      extra_requirements:
+        - anemoi-datasets==0.5.35
+      forecaster:
+        checkpoint: https://service.meteoswiss.ch/mlstore#/models/sruc-m-1-forecaster/versions/4
+        config: resources/inference/configs/sgm-multidataset-forecaster-global-ich1-oper.yaml
+        steps: 0/12/6
+  - baseline:
+      label: INCA
+      root: /store_new/mch/msclim/INCA
+      steps: 0/6/1
+  - baseline:
+      label: ICON-CH2-CTRL
+      root: /store_new/mch/msopr/osm/ICON-CH2-EPS
+      steps: 0/12/1
+  - baseline:
+      label: ICON-CH1-CTRL
+      root: /store_new/mch/msopr/osm/ICON-CH1-EPS
+      steps: 0/12/1
+
+truth:
+  label: SwissMetNet
+  root: jretrievedwh:1,2
+  # To verify against SwissMetNet observations from the DWH via jretrievedwh,
+  # set instead (requires jretrievedwh.py on $PATH and $OPR_HOME set):
+  # Other selectors: root: jretrievedwh:locations=ARO,KLO,LUG
+  #                  root: jretrievedwh:bbox=45.8,47.8,5.9,10.5
+  #                  append ;stage=devt to target a non-prod DWH stage
+
+experiment:
+  params:
+    - T_2M
+    - SP_10M
+    - TOT_PREC6
+  stratification:
+    regions:
+      - mittelland
+      - berge
+      - alpennordseite
+      - alpensuedseite
+      - jura
+    root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
+  thresholds:
+    TOT_PREC6:
+      gt: [0.0, 0.1, 5, 10, 20, 50]
+    SP_10M:
+      gt: [2.5, 5.0, 10.0]
+    T_2M:
+      lt: [273.15]
+      gt: [288.15, 298.15]
+  dashboard:
+    stratification:
+      # - region
+      # - init_hour
+      - season
+  scorecards:
+    enabled: true
+    sections:
+      nowcasting:
+        baseline: INCA
+        lead_times: "0/6/1"
+        stratification: region
+        variables:
+          - "U_10M:RMSE,R2,ETS"
+          - "V_10M:RMSE,R2,ETS"
+          - "T_2M:RMSE,R2,ETS"
+          - "TOT_PREC1:RMSE,R2,ETS"
+      short_range:
+        baseline: ICON-CH1-CTRL
+        lead_times: "6/12/6"
+        stratification: region
+        variables:
+          - "U_10M:RMSE,R2,ETS"
+          - "V_10M:RMSE,R2,ETS"
+          - "T_2M:RMSE,R2,ETS"
+          - "TOT_PREC6:RMSE,R2,ETS"
+  scoremaps:
+    enabled: false
+
+locations:
+  output_root: output/
+
+profile:
+  executor: slurm
+  global_resources:
+    gpus: 16
+  default_resources:
+    slurm_partition: "postproc"
+    cpus_per_task: 1
+    mem_mb_per_cpu: 1800
+    runtime: "1h"
+    gpus: 0
+  jobs: 50

--- a/tests/integration/configs/dashboard_small.yaml
+++ b/tests/integration/configs/dashboard_small.yaml
@@ -32,10 +32,6 @@ runs:
       root: /store_new/mch/msclim/INCA
       steps: 0/6/1
   - baseline:
-      label: ICON-CH2-CTRL
-      root: /store_new/mch/msopr/osm/ICON-CH2-EPS
-      steps: 0/12/1
-  - baseline:
       label: ICON-CH1-CTRL
       root: /store_new/mch/msopr/osm/ICON-CH1-EPS
       steps: 0/12/1
@@ -58,18 +54,15 @@ experiment:
     regions:
       - mittelland
       - berge
-      - alpennordseite
-      - alpensuedseite
-      - jura
     root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
   thresholds:
     TOT_PREC6:
-      gt: [0.0, 0.1, 5, 10, 20, 50]
+      gt: [0.0, 0.1]
     SP_10M:
-      gt: [2.5, 5.0, 10.0]
+      gt: [2.5, 10.0]
     T_2M:
       lt: [273.15]
-      gt: [288.15, 298.15]
+      gt: [288.15]
   dashboard:
     stratification:
       # - region
@@ -83,18 +76,16 @@ experiment:
         lead_times: "0/6/1"
         stratification: region
         variables:
-          - "U_10M:RMSE,R2,ETS"
-          - "V_10M:RMSE,R2,ETS"
           - "T_2M:RMSE,R2,ETS"
-          - "TOT_PREC1:RMSE,R2,ETS"
+          - "SP_10M:RMSE,R2,ETS"
+          - "TOT_PREC6:RMSE,R2,ETS"
       short_range:
         baseline: ICON-CH1-CTRL
         lead_times: "6/12/6"
         stratification: region
         variables:
-          - "U_10M:RMSE,R2,ETS"
-          - "V_10M:RMSE,R2,ETS"
           - "T_2M:RMSE,R2,ETS"
+          - "SP_10M:RMSE,R2,ETS"
           - "TOT_PREC6:RMSE,R2,ETS"
   scoremaps:
     enabled: false

--- a/tests/integration/configs/dashboard_small.yaml
+++ b/tests/integration/configs/dashboard_small.yaml
@@ -10,7 +10,7 @@ config_label: dashboard-test
 # must run real inference, so temporarily comment this line out, run
 # `evalml experiment <this config>`, then `evalml capture-fixture <this config>
 # <path>`, and restore it (see tests/integration/README.md).
-#fixture_root: /scratch/mch/mmcgloho/evalml_test_fixtures/dashboard-small
+fixture_root: /scratch/mch/mmcgloho/evalml_test_fixtures/dashboard-small
 
 dates:
   - 2024-08-01T00:00

--- a/tests/integration/configs/dashboard_small.yaml
+++ b/tests/integration/configs/dashboard_small.yaml
@@ -48,21 +48,29 @@ truth:
 experiment:
   params:
     - T_2M
+    - TD_2M
     - SP_10M
+    - TOT_PREC1
     - TOT_PREC6
+    - PMSL
   stratification:
     regions:
       - mittelland
       - berge
+      - alpennordseite
+      - alpensuedseite
+      - jura
     root: /store_new/mch/msopr/ml/regions/Prognoseregionen_LV95_20220517
   thresholds:
+    TOT_PREC1:
+      gt: [0.0, 0.1, 1, 5, 10]
     TOT_PREC6:
-      gt: [0.0, 0.1]
+      gt: [0.0, 0.1, 5, 10, 20, 50]
     SP_10M:
-      gt: [2.5, 10.0]
+      gt: [2.5, 5.0, 10.0]
     T_2M:
       lt: [273.15]
-      gt: [288.15]
+      gt: [288.15, 298.15]
   dashboard:
     stratification:
       # - region
@@ -76,16 +84,18 @@ experiment:
         lead_times: "0/6/1"
         stratification: region
         variables:
+          - "U_10M:RMSE,R2,ETS"
+          - "V_10M:RMSE,R2,ETS"
           - "T_2M:RMSE,R2,ETS"
-          - "SP_10M:RMSE,R2,ETS"
-          - "TOT_PREC6:RMSE,R2,ETS"
+          - "TOT_PREC1:RMSE,R2,ETS"
       short_range:
         baseline: ICON-CH1-CTRL
         lead_times: "6/12/6"
         stratification: region
         variables:
+          - "U_10M:RMSE,R2,ETS"
+          - "V_10M:RMSE,R2,ETS"
           - "T_2M:RMSE,R2,ETS"
-          - "SP_10M:RMSE,R2,ETS"
           - "TOT_PREC6:RMSE,R2,ETS"
   scoremaps:
     enabled: false

--- a/tests/integration/configs/meteogram_small.yaml
+++ b/tests/integration/configs/meteogram_small.yaml
@@ -10,7 +10,7 @@ config_label: meteogram-test
 # must run real inference, so temporarily comment this line out, run
 # `evalml showcase <this config>`, then `evalml capture-fixture <this config>
 # <path>`, and restore it (see tests/integration/README.md).
-fixture_root: /store_new/mch/msopr/cmerker/evalml_test_fixtures/meteogram-small
+fixture_root: /store_new/mch/msopr/ml/evalml/test_fixtures/meteogram-small
 
 dates:
   - 2024-08-01T00:00

--- a/tests/integration/test_dashboard_small.py
+++ b/tests/integration/test_dashboard_small.py
@@ -2,10 +2,16 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 CONFIG = Path(__file__).resolve().parent / "configs" / "dashboard_small.yaml"
 
+# The config always replays inference from its `fixture_root` (no GPU / MLflow /
+# sandbox build); truth still comes live from the DWH. Read the path from the
+# config so the test and config never disagree.
+
+FIXTURE_ROOT = Path(yaml.safe_load(CONFIG.read_text())["fixture_root"])
 
 @pytest.mark.longtest
 def test_experiment_dashboard():
@@ -17,6 +23,15 @@ def test_experiment_dashboard():
     skipped in ordinary test runs. PNG existence is not checked explicitly because
     snakemake fails if they are not produced.
     """
+    # A completed capture writes MANIFEST.yaml; keying off that (not mere
+    # directory existence) avoids running against an empty/partial fixture.
+    if not (FIXTURE_ROOT / "MANIFEST.yaml").exists():
+        pytest.skip(
+            f"inference fixture not populated at {FIXTURE_ROOT}; create it once with "
+            f"`evalml capture-fixture {CONFIG} {FIXTURE_ROOT}` after a real GPU run "
+            "(see tests/integration/README.md)."
+        )
+
     result = subprocess.run(
         ["evalml", "experiment", str(CONFIG), "--report"],
         cwd=PROJECT_ROOT,

--- a/tests/integration/test_dashboard_small.py
+++ b/tests/integration/test_dashboard_small.py
@@ -18,10 +18,10 @@ def test_experiment_dashboard():
     """Run the experiment workflow on a minimal config and check dashboard is produced.
 
     Drives the ``evalml experiment`` pipeline post-inference.
-    Marked ``longtest`` because it needs a GPU, MLflow credentials, DWH
-    (jretrievedwh) credentials, and access to the /store_new datasets, so it is
-    skipped in ordinary test runs. PNG existence is not checked explicitly because
-    snakemake fails if they are not produced.
+    Marked ``longtest`` because it needs DWH (jretrievedwh) credentials and
+    access to the /store_new datasets, so it is skipped in ordinary test runs.
+    PNG/HTML existence is not checked explicitly because snakemake fails if they
+    are not produced.
     """
     # A completed capture writes MANIFEST.yaml; keying off that (not mere
     # directory existence) avoids running against an empty/partial fixture.

--- a/tests/integration/test_dashboard_small.py
+++ b/tests/integration/test_dashboard_small.py
@@ -1,0 +1,30 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = Path(__file__).resolve().parent / "configs" / "dashboard_small.yaml"
+
+
+@pytest.mark.longtest
+def test_experiment_dashboard():
+    """Run the experiment workflow on a minimal config and check dashboard is produced.
+
+    Drives the ``evalml experiment`` pipeline post-inference.
+    Marked ``longtest`` because it needs a GPU, MLflow credentials, DWH
+    (jretrievedwh) credentials, and access to the /store_new datasets, so it is
+    skipped in ordinary test runs. PNG existence is not checked explicitly because
+    snakemake fails if they are not produced.
+    """
+    result = subprocess.run(
+        ["evalml", "experiment", str(CONFIG), "--report"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"evalml experiment failed (exit {result.returncode}).\n"
+        f"stdout tail:\n{result.stdout[-2000:]}\n"
+        f"stderr tail:\n{result.stderr[-2000:]}"
+    )

--- a/tools/summarize_logs.py
+++ b/tools/summarize_logs.py
@@ -18,6 +18,11 @@ DEST.mkdir(exist_ok=True)
 
 ERROR_KEYWORDS = {"error", "exception", "traceback", "failed", "oom", "killed"}
 
+# Known-benign noise that happens to contain an ERROR_KEYWORDS substring.
+# eckit prints this directly (no logger prefix) when a grid-cache lock file is
+# already gone by the time it tries to clean it up afterward — harmless.
+BENIGN_PATTERNS = ("unlink failed",)
+
 
 def copy(src: Path, dest_root: Path) -> Path:
     rel = src.relative_to(ROOT)
@@ -41,9 +46,10 @@ def read(path: Path, max_lines: int = 300) -> str:
 
 def has_error(path: Path) -> bool:
     try:
-        return any(
-            kw in path.read_text(errors="replace").lower() for kw in ERROR_KEYWORDS
-        )
+        text = path.read_text(errors="replace").lower()
+        for pattern in BENIGN_PATTERNS:
+            text = text.replace(pattern, "")
+        return any(kw in text for kw in ERROR_KEYWORDS)
     except Exception:
         return False
 


### PR DESCRIPTION
Creates an integration test for the dashboard, using `eval experiment` worfklow.

Uses test fixture to allow skipping inference.