### PR TITLE
Scale the number of physical cores requested with the expected memory usage

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -469,6 +469,22 @@ PARAMS_WITHOUT_STEP_ZERO_VALUE = {
 }
 
 
+def balfrin_cpus(mem_mb, actual_cpus=1, node_mem_mb=512_000, node_cpus=256):
+    """Minimum cores to request on Balfrin based on memory usage.
+
+    Balfrin CPU nodes have no per-job memory control: any job can consume the
+    full node memory (512 GB / 256 cores).  To avoid starving other jobs,
+    reserve cores proportional to expected memory so the scheduler implicitly
+    limits total memory usage:
+
+        cores = max(actual_cpus, ceil(mem_mb / node_mem_mb * node_cpus))
+    """
+    import math
+
+    mem_cpus = math.ceil(mem_mb / node_mem_mb * node_cpus)
+    return max(actual_cpus, mem_cpus)
+
+
 def resolve_leadtimes(steps_spec, requested="all", param=None):
     """Lead times to compute for a single participant.
 

--- a/workflow/rules/verification.smk
+++ b/workflow/rules/verification.smk
@@ -21,7 +21,7 @@ rule verification_metrics_baseline:
     log:
         OUT_ROOT / "logs/verification_metrics_baseline/{baseline_id}-{init_time}.log",
     resources:
-        cpus_per_task=24,
+        cpus_per_task=balfrin_cpus(80_000, actual_cpus=24),
         mem_mb=80_000,
         runtime="120m",
     params:
@@ -75,7 +75,7 @@ rule verification_metrics:
     log:
         OUT_ROOT / "logs/verification_metrics/{run_id}-{init_time}.log",
     resources:
-        cpus_per_task=24,
+        cpus_per_task=balfrin_cpus(80_000, actual_cpus=24),
         mem_mb=80_000,
         runtime="60m",
     # wildcard_constraints:
@@ -134,7 +134,7 @@ rule verification_metrics_aggregation:
     log:
         OUT_ROOT / "logs/verification_metrics_aggregation/{run_id}.log",
     resources:
-        cpus_per_task=24,
+        cpus_per_task=balfrin_cpus(250_000, actual_cpus=24),
         mem_mb=250_000,
         runtime="2h",
     shell:
@@ -170,7 +170,7 @@ rule verification_metrics_plot:
     log:
         OUT_ROOT / "logs/verification_metrics_plot/{experiment}.log",
     resources:
-        cpus_per_task=16,
+        cpus_per_task=balfrin_cpus(50_000, actual_cpus=16),
         mem_mb=50_000,
         runtime="20m",
     params:
@@ -210,7 +210,7 @@ rule verification_scoremaps:
         OUT_ROOT
         / f"logs/verification_scoremaps/{{run_id}}-{TRUTH_HASH}-{{param}}-{{leadtime}}.log",
     resources:
-        cpus_per_task=2,
+        cpus_per_task=balfrin_cpus(50_000, actual_cpus=2),
         mem_mb=50_000,
         runtime="60m",
     # wildcard_constraints:
@@ -250,7 +250,7 @@ rule verification_scoremaps_baseline:
         OUT_ROOT
         / f"logs/verification_scoremaps_baseline/{{baseline_id}}-{TRUTH_HASH}-{{param}}-{{leadtime}}.log",
     resources:
-        cpus_per_task=24,
+        cpus_per_task=balfrin_cpus(50_000, actual_cpus=24),
         mem_mb=50_000,
         runtime="60m",
     params:


### PR DESCRIPTION
On balfrin there is no memory control, in principle every job can use the whole memory of the node, e.g. 512 GB - which may lead to job failures in case the total memory is exceeded.
As workaround, it was proposed to user who have jobs using large amount of memory, e.g. more than 2 GB, to scale the number of physical cores requested, with the expected memory usage (even if you are using only one effectively). 

This PR applies this guideline to evalml where relevant.

FYI @lxavier 