### PR TITLE
Change order of operations for ensemble mean of derived parameters

### DIFF
--- a/src/data_input/__init__.py
+++ b/src/data_input/__init__.py
@@ -1248,6 +1248,9 @@ def _load_icon_baseline_from_grib(
                 )
                 if "number" in ds.dims:
                     ds = ds.isel(number=0, drop=True)
+                for _p, _comps in DERIVED_PARAMS.items():
+                    if all(c in ds.data_vars for c in _comps):
+                        ds = ds.assign({_p: compute_derived(ds, _p)})
                 acc = ds if acc is None else acc + ds
                 n_loaded += 1
             except Exception as exc:


### PR DESCRIPTION
For all derived quantities, the order of operation to compute the ensemble mean needs fixing. First we need to compute the derived parameter per ensemble member, then average (now we're doing it in reverse).

For aggregated parameters, this is a non-issue as long as we only compute the ensemble mean (not median or other ensemble statistics).

## Summary of changes
* change order of operations for derived parameters