### PR TITLE
fix: pass slurm account to inference srun call

### DIFF
--- a/workflow/rules/inference.smk
+++ b/workflow/rules/inference.smk
@@ -284,6 +284,11 @@ rule inference_execute:
         disable_local_definitions=lambda wc: RUN_CONFIGS[wc.run_id].get(
             "disable_local_eccodes_definitions", False
         ),
+        account_flag=lambda wc: (
+            f"--account={config['profile']['default_resources']['slurm_account']}"
+            if config["profile"]["default_resources"].get("slurm_account")
+            else ""
+        ),
     # fmt: off
     shell:
         """
@@ -309,6 +314,7 @@ rule inference_execute:
 
                 srun \
                     --unbuffered \
+                    {params.account_flag} \
                     --partition={resources.slurm_partition} \
                     --cpus-per-task={resources.cpus_per_task} \
                     --mem-per-cpu={resources.mem_mb_per_cpu} \


### PR DESCRIPTION
## Summary
- The `inference_execute` rule runs `anemoi-inference` via a nested `srun` inside a `squashfs-mount ... bash -c` block, separate from snakemake's own job submission
- `slurm_account` (added in #180) was only wired into snakemake's `--default-resources`, so it never reached this inner `srun` call. This meant that GPU inference jobs ran under the cluster's default account instead of the one configured in `profile.default_resources.slurm_account`
- Adds an `account_flag` param that renders `--account=<slurm_account>` when configured, or an empty string otherwise, and passes it to the inner `srun` call.
